### PR TITLE
Add configmap mariadb-glpi-config

### DIFF
--- a/kubernetes/glpi-deployment.yaml
+++ b/kubernetes/glpi-deployment.yaml
@@ -7,7 +7,7 @@ metadata:
     app: php-fpm
   namespace: glpi
 spec:
-  replicas: 2
+  replicas: 1
   selector:
     matchLabels:
       app: php-fpm
@@ -57,7 +57,7 @@ metadata:
     app: nginx
   namespace: glpi 
 spec:
-  replicas: 2
+  replicas: 1
   selector:
     matchLabels:
       app: nginx

--- a/kubernetes/glpi-persistentvolumeclaim.yaml
+++ b/kubernetes/glpi-persistentvolumeclaim.yaml
@@ -5,9 +5,10 @@ metadata:
   name: glpi-files
   namespace: glpi
 spec:
-  storageClassName: longhorn
+  # storageClassName: longhorn
   accessModes:
-    - ReadWriteMany
+    # - ReadWriteMany
+    - ReadWriteOnce
   resources:
     requests:
       storage: 10Gi
@@ -19,9 +20,10 @@ metadata:
   name: glpi-marketplace
   namespace: glpi
 spec:
-  storageClassName: longhorn
+  # storageClassName: longhorn
   accessModes:
-    - ReadWriteMany
+#    - ReadWriteMany
+    - ReadWriteOnce
   resources:
     requests:
       storage: 2Gi
@@ -35,9 +37,10 @@ metadata:
   name: glpi-etc
   namespace: glpi
 spec:
-  storageClassName: longhorn
+  # storageClassName: longhorn
   accessModes:
-    - ReadWriteMany
+#    - ReadWriteMany
+    - ReadWriteOnce
   resources:
     requests:
       storage: 50Mi

--- a/kubernetes/mariadb-configmap.yaml
+++ b/kubernetes/mariadb-configmap.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ConfigMap
+metadata: 
+  name: mariadb-glpi-config
+  namespace: glpi 
+data: 
+  MARIADB_HOST: "mariadb-headless.glpi.svc.cluster.local"
+  MARIADB_PORT: "3306"

--- a/kubernetes/mariadb-job.yaml
+++ b/kubernetes/mariadb-job.yaml
@@ -11,12 +11,15 @@ spec:
         imagePullPolicy: IfNotPresent
         name: base
         command:
-        - sh 
-        - -c
-        - "mysql -h $MARIADB_HOST -u root -p$MARIADB_ROOT_PASSWORD -e \"GRANT SELECT ON \`mysql\`.\`time_zone_name\` TO 'glpi'@'%'; FLUSH PRIVILEGES; FLUSH PRIVILEGES;\""
+        - sh
+        - -c 
+        - "mysql --host=${MARIADB_HOST} -u root -p${MARIADB_ROOT_PASSWORD} -e \"GRANT SELECT ON mysql.time_zone_name TO 'glpi'@'%'; FLUSH PRIVILEGES;\""
         envFrom: 
         - secretRef: 
             name: mariadb-glpi-secret
+        - configMapRef: 
+            name: mariadb-glpi-config
+
       restartPolicy: Never
   backoffLimit: 5
 status: {}

--- a/kubernetes/mariadb-persistentvolumeclaim.yaml
+++ b/kubernetes/mariadb-persistentvolumeclaim.yaml
@@ -6,7 +6,7 @@ metadata:
   name: mariadb-data
   namespace: glpi 
 spec:
-  storageClassName: longhorn
+  # storageClassName: longhorn
   accessModes:
     - ReadWriteOnce
   resources:

--- a/kubernetes/mariadb-secret.yaml
+++ b/kubernetes/mariadb-secret.yaml
@@ -6,7 +6,7 @@ metadata:
   name: mariadb-glpi-secret
   namespace: glpi 
 data: 
-  MARIADB_ROOT_PASSWORD: bXktc2VjcmV0LXB3Cg==
+  MARIADB_ROOT_PASSWORD: Z2xwaQ==
   MARIADB_DATABASE: Z2xwaQ==
   MARIADB_USER: Z2xwaQ==
   MARIADB_PASSWORD: Z2xwaQ==


### PR DESCRIPTION
On branch 57-job-could-not-be-applied
Changes to be committed:
	modified:   kubernetes/glpi-deployment.yaml
	modified:   kubernetes/glpi-persistentvolumeclaim.yaml
	new file:   kubernetes/mariadb-configmap.yaml
	modified:   kubernetes/mariadb-job.yaml
	modified:   kubernetes/mariadb-persistentvolumeclaim.yaml
	modified:   kubernetes/mariadb-secret.yaml