### PR TITLE
GLPI images to v11.0.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ Manifest files for building and deploying **GLPI** using containers with Docker 
 
 - [x] PHP-FPM: `php:8.4.13-fpm-alpine3.22`
 - [x] Nginx: `nginxinc/nginx-unprivileged:1.29.1-alpine3.22-slim`
-- [x] GLPI PHP: `eftechcombr/glpi:php-fpm-11.0.1`
-- [x] GLPI Nginx: `eftechcombr/glpi:nginx-11.0.1`
+- [x] GLPI PHP: `eftechcombr/glpi:php-fpm-11.0.2`
+- [x] GLPI Nginx: `eftechcombr/glpi:nginx-11.0.2`
 
 ## Quick Start
 

--- a/docker/.env.example
+++ b/docker/.env.example
@@ -1,5 +1,5 @@
 GLPI_LANG="en_US"
-VERSION="11.0.1"
+VERSION="11.0.2"
 GLPI_MARKETPLACE_DIR=/var/www/html/marketplace
 GLPI_VAR_DIR=/var/lib/glpi
 GLPI_DOC_DIR=/var/lib/glpi

--- a/docker/docker-compose-build.yml
+++ b/docker/docker-compose-build.yml
@@ -22,7 +22,7 @@ services:
     command: mariadb -h $MARIADB_HOST -u root -p$MARIADB_ROOT_PASSWORD -e "GRANT SELECT ON \`mysql\`.\`time_zone_name\` TO 'glpi'@'%'; FLUSH PRIVILEGES;"
 
   glpi-db-install:
-    image: eftechcombr/glpi:php-fpm-11.0.1
+    image: eftechcombr/glpi:php-fpm-11.0.2
     restart: on-failure 
     env_file: ./.env
     volumes: 
@@ -35,7 +35,7 @@ services:
       - /usr/local/bin/glpi-db-install.sh
 
   glpi-verify-dir: 
-    image: eftechcombr/glpi:php-fpm-11.0.1
+    image: eftechcombr/glpi:php-fpm-11.0.2
     restart: on-failure
     volumes: 
       - glpi-marketplace:/var/www/html/marketplace:rw
@@ -48,7 +48,7 @@ services:
       - /usr/local/bin/glpi-verify-dir.sh
 
   glpi-db-configure: 
-    image: eftechcombr/glpi:php-fpm-11.0.1
+    image: eftechcombr/glpi:php-fpm-11.0.2
     restart: on-failure
     volumes: 
       - glpi-marketplace:/var/www/html/marketplace:rw
@@ -61,7 +61,7 @@ services:
       - /usr/local/bin/glpi-db-configure.sh
 
   glpi-cache-configure: 
-    image: eftechcombr/glpi:php-fpm-11.0.1
+    image: eftechcombr/glpi:php-fpm-11.0.2
     restart: on-failure
     volumes: 
       - glpi-marketplace:/var/www/html/marketplace:rw
@@ -84,7 +84,7 @@ services:
 
   php: 
     build: php/
-    image: eftechcombr/glpi:php-fpm-11.0.1
+    image: eftechcombr/glpi:php-fpm-11.0.2
     restart: unless-stopped
     volumes: 
       - glpi-marketplace:/var/www/html/marketplace:rw
@@ -101,7 +101,7 @@ services:
 
   nginx: 
     build: nginx/
-    image: eftechcombr/glpi:nginx-11.0.1
+    image: eftechcombr/glpi:nginx-11.0.2
     restart: unless-stopped
     ports: 
       - "8080:8080"

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -22,7 +22,7 @@ services:
     command: mariadb -h $MARIADB_HOST -u root -p$MARIADB_ROOT_PASSWORD -e "GRANT SELECT ON \`mysql\`.\`time_zone_name\` TO 'glpi'@'%'; FLUSH PRIVILEGES;"
 
   glpi-db-install:
-    image: eftechcombr/glpi:php-fpm-11.0.1
+    image: eftechcombr/glpi:php-fpm-11.0.2
     restart: on-failure 
     env_file: ./.env
     volumes: 
@@ -35,7 +35,7 @@ services:
       - /usr/local/bin/glpi-db-install.sh
 
   glpi-verify-dir: 
-    image: eftechcombr/glpi:php-fpm-11.0.1
+    image: eftechcombr/glpi:php-fpm-11.0.2
     restart: on-failure
     volumes: 
       - glpi-marketplace:/var/www/html/marketplace:rw
@@ -48,7 +48,7 @@ services:
       - /usr/local/bin/glpi-verify-dir.sh
 
   glpi-db-configure: 
-    image: eftechcombr/glpi:php-fpm-11.0.1
+    image: eftechcombr/glpi:php-fpm-11.0.2
     restart: on-failure
     volumes: 
       - glpi-marketplace:/var/www/html/marketplace:rw
@@ -60,7 +60,7 @@ services:
     command: 
       - /usr/local/bin/glpi-db-configure.sh
   glpi-cache-configure: 
-    image: eftechcombr/glpi:php-fpm-11.0.1
+    image: eftechcombr/glpi:php-fpm-11.0.2
     restart: on-failure
     volumes: 
       - glpi-marketplace:/var/www/html/marketplace:rw
@@ -73,7 +73,7 @@ services:
       - /usr/local/bin/glpi-cache-configure.sh
 
   php: 
-    image: eftechcombr/glpi:php-fpm-11.0.1
+    image: eftechcombr/glpi:php-fpm-11.0.2
     restart: unless-stopped
     volumes: 
       - glpi-marketplace:/var/www/html/marketplace:rw
@@ -89,7 +89,7 @@ services:
       - "9000:9000"
 
   nginx: 
-    image: eftechcombr/glpi:nginx-11.0.1
+    image: eftechcombr/glpi:nginx-11.0.2
     restart: unless-stopped
     ports: 
       - "8080:8080"

--- a/docker/nginx/Dockerfile
+++ b/docker/nginx/Dockerfile
@@ -1,4 +1,4 @@
-FROM eftechcombr/glpi:php-fpm-11.0.1 as BUILD
+FROM eftechcombr/glpi:php-fpm-11.0.2 as BUILD
 #
 
 FROM nginxinc/nginx-unprivileged:1.27.5-alpine3.21-slim

--- a/docker/php/Dockerfile
+++ b/docker/php/Dockerfile
@@ -1,6 +1,6 @@
 FROM eftechcombr/glpi:base 
 
-ENV VERSION=11.0.1 
+ENV VERSION=11.0.2 
 ENV GLPI_LANG=en_US 
 ENV CACHE_DSN=redis://redis:6379/
 ENV MARIADB_HOST=mariadb-glpi 

--- a/kubernetes/glpi-configmap.yaml
+++ b/kubernetes/glpi-configmap.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: glpi 
 data: 
   GLPI_LANG: "en_US"
-  VERSION: "11.0.1"
+  VERSION: "11.0.2"
   GLPI_MARKETPLACE_DIR: /var/www/html/marketplace
   GLPI_VAR_DIR: /var/lib/glpi
   GLPI_DOC_DIR: /var/lib/glpi

--- a/kubernetes/glpi-cronjob.yaml
+++ b/kubernetes/glpi-cronjob.yaml
@@ -15,7 +15,7 @@ spec:
       template:
         spec:
           containers:
-          - image: eftechcombr/glpi:php-fpm-11.0.1
+          - image: eftechcombr/glpi:php-fpm-11.0.2
             imagePullPolicy: IfNotPresent
             name: base
             envFrom: 

--- a/kubernetes/glpi-deployment.yaml
+++ b/kubernetes/glpi-deployment.yaml
@@ -17,7 +17,7 @@ spec:
         app: php-fpm
     spec:
       containers:
-      - image: eftechcombr/glpi:php-fpm-11.0.1
+      - image: eftechcombr/glpi:php-fpm-11.0.2
         imagePullPolicy: IfNotPresent
         name: php
         envFrom: 
@@ -67,7 +67,7 @@ spec:
         app: nginx
     spec:
       containers:
-      - image: eftechcombr/glpi:nginx-11.0.1
+      - image: eftechcombr/glpi:nginx-11.0.2
         imagePullPolicy: IfNotPresent
         name: nginx
         envFrom: 

--- a/kubernetes/glpi-job.yaml
+++ b/kubernetes/glpi-job.yaml
@@ -8,7 +8,7 @@ spec:
   template:
     spec:
       containers:
-      - image: eftechcombr/glpi:php-fpm-11.0.1
+      - image: eftechcombr/glpi:php-fpm-11.0.2
         imagePullPolicy: IfNotPresent
         name: base
         envFrom: 
@@ -54,7 +54,7 @@ spec:
   template:
     spec:
       containers:
-      - image: eftechcombr/glpi:php-fpm-11.0.1
+      - image: eftechcombr/glpi:php-fpm-11.0.2
         imagePullPolicy: IfNotPresent
         name: base
         command:
@@ -99,7 +99,7 @@ spec:
   template:
     spec:
       containers:
-      - image: eftechcombr/glpi:php-fpm-11.0.1
+      - image: eftechcombr/glpi:php-fpm-11.0.2
         imagePullPolicy: IfNotPresent
         name: base
         command:
@@ -144,7 +144,7 @@ spec:
   template:
     spec:
       containers:
-      - image: eftechcombr/glpi:php-fpm-11.0.1
+      - image: eftechcombr/glpi:php-fpm-11.0.2
         imagePullPolicy: IfNotPresent
         name: base
         command:


### PR DESCRIPTION
🛠️ docker/.env.example -> set VERSION=11.0.2
🛠️ docker/docker-compose-build.yml -> update image tags to 11.0.2 🛠️ docker/docker-compose.yml -> update image tags to 11.0.2 🛠️ docker/nginx/Dockerfile -> change BUILD base to 11.0.2 🛠️ docker/php/Dockerfile -> set ENV VERSION=11.0.2 🛠️ kubernetes/glpi-configmap.yaml -> update VERSION to 11.0.2 🛠️ kubernetes/glpi-cronjob.yaml -> image tag to 11.0.2 🛠️ kubernetes/glpi-deployment.yaml -> image tags to 11.0.2 🛠️ kubernetes/glpi-job.yaml -> all containers image to 11.0.2