### PR TITLE
Remove /api location rewrite rule

### DIFF
--- a/docker/nginx/conf.d/default.conf
+++ b/docker/nginx/conf.d/default.conf
@@ -10,10 +10,6 @@ server {
         try_files $uri /index.php$is_args$args;
     }
 
-   location /api {
-        rewrite ^/api/(.*)$ /apirest.php/$1 last;
-   }
-
     location ~ ^/index\.php$ {
         # the following line needs to be adapted, as it changes depending on OS distributions and PHP versions
         # fastcgi_pass unix:/run/php/php-fpm.sock;


### PR DESCRIPTION
Removed API rewrite rule from Nginx configuration.

Removed because GLPI 11 API breaks with it enabled, works fine without it though. (GLPI documentation apparently not updated)