### PR TITLE
Update from 11.0.3 to 11.0.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ Manifest files for building and deploying **GLPI** using containers with Docker 
 
 - [x] PHP-FPM: `php:8.4.13-fpm-alpine3.22`
 - [x] Nginx: `nginxinc/nginx-unprivileged:1.29.1-alpine3.22-slim`
-- [x] GLPI PHP: `eftechcombr/glpi:php-fpm-11.0.3`
-- [x] GLPI Nginx: `eftechcombr/glpi:nginx-11.0.3`
+- [x] GLPI PHP: `eftechcombr/glpi:php-fpm-11.0.4`
+- [x] GLPI Nginx: `eftechcombr/glpi:nginx-11.0.4`
 
 ## Quick Start
 

--- a/docker/.env.example
+++ b/docker/.env.example
@@ -1,5 +1,5 @@
 GLPI_LANG="en_US"
-VERSION="11.0.3"
+VERSION="11.0.4"
 GLPI_MARKETPLACE_DIR=/var/www/html/marketplace
 GLPI_VAR_DIR=/var/lib/glpi
 GLPI_DOC_DIR=/var/lib/glpi

--- a/docker/docker-compose-build.yml
+++ b/docker/docker-compose-build.yml
@@ -22,7 +22,7 @@ services:
     command: mariadb -h $MARIADB_HOST -u root -p$MARIADB_ROOT_PASSWORD -e "GRANT SELECT ON \`mysql\`.\`time_zone_name\` TO 'glpi'@'%'; FLUSH PRIVILEGES;"
 
   glpi-db-install:
-    image: eftechcombr/glpi:php-fpm-11.0.3
+    image: eftechcombr/glpi:php-fpm-11.0.4
     restart: on-failure 
     env_file: ./.env
     volumes: 
@@ -35,7 +35,7 @@ services:
       - /usr/local/bin/glpi-db-install.sh
 
   glpi-verify-dir: 
-    image: eftechcombr/glpi:php-fpm-11.0.3
+    image: eftechcombr/glpi:php-fpm-11.0.4
     restart: on-failure
     volumes: 
       - glpi-marketplace:/var/www/html/marketplace:rw
@@ -48,7 +48,7 @@ services:
       - /usr/local/bin/glpi-verify-dir.sh
 
   glpi-db-configure: 
-    image: eftechcombr/glpi:php-fpm-11.0.3
+    image: eftechcombr/glpi:php-fpm-11.0.4
     restart: on-failure
     volumes: 
       - glpi-marketplace:/var/www/html/marketplace:rw
@@ -61,7 +61,7 @@ services:
       - /usr/local/bin/glpi-db-configure.sh
 
   glpi-cache-configure: 
-    image: eftechcombr/glpi:php-fpm-11.0.3
+    image: eftechcombr/glpi:php-fpm-11.0.4
     restart: on-failure
     volumes: 
       - glpi-marketplace:/var/www/html/marketplace:rw
@@ -84,7 +84,7 @@ services:
 
   php: 
     build: php/
-    image: eftechcombr/glpi:php-fpm-11.0.3
+    image: eftechcombr/glpi:php-fpm-11.0.4
     restart: unless-stopped
     volumes: 
       - glpi-marketplace:/var/www/html/marketplace:rw
@@ -101,7 +101,7 @@ services:
 
   nginx: 
     build: nginx/
-    image: eftechcombr/glpi:nginx-11.0.3
+    image: eftechcombr/glpi:nginx-11.0.4
     restart: unless-stopped
     ports: 
       - "8080:8080"

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -22,7 +22,7 @@ services:
     command: mariadb -h $MARIADB_HOST -u root -p$MARIADB_ROOT_PASSWORD -e "GRANT SELECT ON \`mysql\`.\`time_zone_name\` TO 'glpi'@'%'; FLUSH PRIVILEGES;"
 
   glpi-db-install:
-    image: eftechcombr/glpi:php-fpm-11.0.3
+    image: eftechcombr/glpi:php-fpm-11.0.4
     restart: on-failure 
     env_file: ./.env
     volumes: 
@@ -35,7 +35,7 @@ services:
       - /usr/local/bin/glpi-db-install.sh
 
   glpi-verify-dir: 
-    image: eftechcombr/glpi:php-fpm-11.0.3
+    image: eftechcombr/glpi:php-fpm-11.0.4
     restart: on-failure
     volumes: 
       - glpi-marketplace:/var/www/html/marketplace:rw
@@ -48,7 +48,7 @@ services:
       - /usr/local/bin/glpi-verify-dir.sh
 
   glpi-db-configure: 
-    image: eftechcombr/glpi:php-fpm-11.0.3
+    image: eftechcombr/glpi:php-fpm-11.0.4
     restart: on-failure
     volumes: 
       - glpi-marketplace:/var/www/html/marketplace:rw
@@ -60,7 +60,7 @@ services:
     command: 
       - /usr/local/bin/glpi-db-configure.sh
   glpi-cache-configure: 
-    image: eftechcombr/glpi:php-fpm-11.0.3
+    image: eftechcombr/glpi:php-fpm-11.0.4
     restart: on-failure
     volumes: 
       - glpi-marketplace:/var/www/html/marketplace:rw
@@ -73,7 +73,7 @@ services:
       - /usr/local/bin/glpi-cache-configure.sh
 
   php: 
-    image: eftechcombr/glpi:php-fpm-11.0.3
+    image: eftechcombr/glpi:php-fpm-11.0.4
     restart: unless-stopped
     volumes: 
       - glpi-marketplace:/var/www/html/marketplace:rw
@@ -89,7 +89,7 @@ services:
       - "9000:9000"
 
   nginx: 
-    image: eftechcombr/glpi:nginx-11.0.3
+    image: eftechcombr/glpi:nginx-11.0.4
     restart: unless-stopped
     ports: 
       - "8080:8080"

--- a/docker/nginx/Dockerfile
+++ b/docker/nginx/Dockerfile
@@ -1,4 +1,4 @@
-FROM eftechcombr/glpi:php-fpm-11.0.3 as BUILD
+FROM eftechcombr/glpi:php-fpm-11.0.4 as BUILD
 #
 
 FROM nginxinc/nginx-unprivileged:1.27.5-alpine3.21-slim

--- a/docker/php/Dockerfile
+++ b/docker/php/Dockerfile
@@ -1,6 +1,6 @@
 FROM eftechcombr/glpi:base 
 
-ENV VERSION=11.0.3 
+ENV VERSION=11.0.4 
 ENV GLPI_LANG=en_US 
 ENV CACHE_DSN=redis://redis:6379/
 ENV MARIADB_HOST=mariadb-glpi 

--- a/kubernetes/glpi/Chart.yaml
+++ b/kubernetes/glpi/Chart.yaml
@@ -21,7 +21,7 @@ version: 1.0.0
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "11.0.3"
+appVersion: "11.0.4"
 
 keywords:
   - glpi

--- a/kubernetes/glpi/values.yaml
+++ b/kubernetes/glpi/values.yaml
@@ -12,7 +12,7 @@ global:
 # -- GLPI Application Configuration
 glpi:
   # GLPI version to deploy
-  version: "11.0.3"
+  version: "11.0.4"
   
   # GLPI default language (e.g., en_US, fr_FR, pt_BR)
   language: "en_US"
@@ -24,7 +24,7 @@ glpi:
       # Image repository for PHP-FPM
       repository: eftechcombr/glpi
       # Image tag for PHP-FPM
-      tag: php-fpm-11.0.3
+      tag: php-fpm-11.0.4
       # Image pull policy
       pullPolicy: IfNotPresent
     
@@ -71,7 +71,7 @@ glpi:
       # Image repository for Nginx
       repository: eftechcombr/glpi
       # Image tag for Nginx
-      tag: nginx-11.0.3
+      tag: nginx-11.0.4
       # Image pull policy
       pullPolicy: IfNotPresent
     


### PR DESCRIPTION
🛠️ README.md → bump GLPI images 11.0.3→11.0.4
🛠️ docker/.env.example → set VERSION 11.0.4
🛠️ docker/docker-compose-build.yml → update image tags to 11.0.4 🛠️ docker/docker-compose.yml → update image tags to 11.0.4 🛠️ docker/nginx/Dockerfile → change base build tag 11.0.4 🛠️ docker/php/Dockerfile → set ENV VERSION 11.0.4
🛠️ kubernetes/glpi/Chart.yaml → appVersion 11.0.4
🛠️ kubernetes/glpi/values.yaml → version, php‑tag, nginx‑tag to 11.0.4