### PR TITLE
chore(docker): replace ADD with COPY in nginx Dockerfile

### DIFF
--- a/docker/nginx/Dockerfile
+++ b/docker/nginx/Dockerfile
@@ -6,7 +6,7 @@ FROM nginxinc/nginx-unprivileged:1.27.5-alpine3.21-slim
 COPY --from=BUILD /var/www/html /var/www/html
 COPY --from=BUILD /var/lib/glpi /var/lib/glpi
 
-ADD conf.d/*.conf /etc/nginx/conf.d/
+COPY conf.d/*.conf /etc/nginx/conf.d/
 
 # Update the default port to 8080 for unprivileged nginx
 EXPOSE 8080


### PR DESCRIPTION
- Replace ADD instruction with COPY for conf.d/*.conf files
- COPY is more explicit and appropriate for file copying operations
- Follows Docker best practices by using COPY instead of ADD when not extracting archives
- Improves clarity and maintainability of the Dockerfile