### PR TITLE
chore(docker): pin php base image dependencies to specific versions

### DIFF
--- a/docker/php/Dockerfile.base
+++ b/docker/php/Dockerfile.base
@@ -6,13 +6,13 @@ RUN mv "$PHP_INI_DIR/php.ini-production" "$PHP_INI_DIR/php.ini"
 
 RUN apk update \
   && apk add --no-cache \
-    icu-dev zlib-dev libpng-dev bzip2-dev libzip-dev openldap-dev \
+    icu-dev=76.1-r1 zlib-dev=1.3.1-r2 libpng-dev=1.6.54-r0 bzip2-dev=1.0.8-r6 libzip-dev=1.11.4-r0 openldap-dev=2.6.8-r0 \
   && docker-php-ext-install \
     intl mysqli gd exif bz2 zip ldap opcache bcmath \ 
-  && apk add --no-cache pcre-dev ${PHPIZE_DEPS} \
+  && apk add --no-cache --virtual .build-deps pcre-dev=8.45-r4 ${PHPIZE_DEPS} \
   && pecl install redis \
   && docker-php-ext-enable redis \
-  && apk del pcre-dev ${PHPIZE_DEPS}
+  && apk del .build-deps
 
 RUN docker-php-source delete
 


### PR DESCRIPTION
- Pin all apk package versions in php/Dockerfile.base to ensure reproducible builds
- Add specific version constraints for icu-dev, zlib-dev, libpng-dev, bzip2-dev, libzip-dev, and openldap-dev
- Pin pcre-dev version to 8.45-r4 for consistency
- Refactor build dependencies to use virtual .build-deps label for cleaner cleanup
- Simplify apk del command to remove only .build-deps virtual package instead of individual packages
- Improves build reproducibility and reduces potential security vulnerabilities from uncontrolled dependency updates