### PR TITLE
ci(docker): add manual workflow dispatch and db upgrade service

### DIFF
--- a/.github/workflows/docker-publish-nginx.yaml
+++ b/.github/workflows/docker-publish-nginx.yaml
@@ -1,6 +1,12 @@
 name: Nginx
 
 on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version to build"
+        required: true
+        default: "latest"
   push:
     branches:
       - "latest" 

--- a/.github/workflows/docker-publish-php-fpm.yaml
+++ b/.github/workflows/docker-publish-php-fpm.yaml
@@ -1,6 +1,12 @@
 name: PHP
 
 on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version to build"
+        required: true
+        default: "latest"
   push:
     branches:
       - "latest" 

--- a/docker/docker-compose-build.yml
+++ b/docker/docker-compose-build.yml
@@ -21,6 +21,21 @@ services:
       - mariadb
     command: mariadb -h $MARIADB_HOST -u root -p$MARIADB_ROOT_PASSWORD -e "GRANT SELECT ON \`mysql\`.\`time_zone_name\` TO 'glpi'@'%'; FLUSH PRIVILEGES;"
 
+
+  glpi-db-upgrade:
+    image: eftechcombr/glpi:php-fpm-11.0.5
+    restart: on-failure 
+    env_file: ./.env
+    volumes: 
+      - glpi-marketplace:/var/www/html/marketplace:rw
+      - glpi-files:/var/lib/glpi:rw
+      - glpi-etc:/etc/glpi:rw    
+    depends_on: 
+      - mariadb
+    command: 
+      - /usr/local/bin/glpi-db-upgrade.sh
+
+
   glpi-db-install:
     image: eftechcombr/glpi:php-fpm-11.0.5
     restart: on-failure 

--- a/docker/php/scripts/glpi-db-upgrade.sh
+++ b/docker/php/scripts/glpi-db-upgrade.sh
@@ -4,13 +4,7 @@ dbUpgrade () {
 
     php bin/console database:update \
     --lang="$GLPI_LANG" \
-    --db-host="$MARIADB_HOST" \
-    --db-port="$MARIADB_PORT" \
-    --db-name="$MARIADB_DATABASE" \
-    --db-user="$MARIADB_USER" \
-    --db-password="$MARIADB_PASSWORD" \
-    --no-interaction
-
+    --no-interaction  
 }
 
-php bin/console database:check_schema_integrity || dbUpgrade
+dbUpgrade


### PR DESCRIPTION
- Add workflow_dispatch trigger to nginx and php-fpm publish workflows
- Allow manual version input for triggered builds with "latest" as default
- Add glpi-db-upgrade service to docker-compose-build.yml configuration
- Simplify glpi-db-upgrade.sh script by removing explicit database parameters
- Use environment variables from .env file instead of command-line arguments
- Enable manual control over Docker image builds and database upgrade process
