### PR TITLE
fix: update PHP version to 8.4.19

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Manifest files for building and deploying **GLPI** using containers with Docker 
 
 ## Supported Containers
 
-- [x] PHP-FPM: `php:8.4.13-fpm-alpine3.22`
+- [x] PHP-FPM: `php:8.4.19-fpm-alpine3.22`
 - [x] Nginx: `nginxinc/nginx-unprivileged:1.29.1-alpine3.22-slim`
 - [x] GLPI PHP: `eftechcombr/glpi:php-fpm-11.0.6`
 - [x] GLPI Nginx: `eftechcombr/glpi:nginx-11.0.6`

--- a/docker/php/Dockerfile.base
+++ b/docker/php/Dockerfile.base
@@ -1,4 +1,4 @@
-FROM php:8.4.14-fpm-alpine3.22
+FROM php:8.4.19-fpm-alpine3.22
 
 COPY conf.d/*.ini $PHP_INI_DIR/conf.d/
 
@@ -8,7 +8,7 @@ RUN apk update \
   && apk add --no-cache \
     icu-dev=76.1-r1 \
     zlib-dev=1.3.1-r2 \
-    libpng-dev=1.6.55-r0 \
+    libpng-dev=1.6.56-r0 \
     bzip2-dev=1.0.8-r6 \
     libzip-dev=1.11.4-r0 \
     openldap-dev=2.6.8-r0 \


### PR DESCRIPTION
## Summary
- Update PHP-FPM base image from 8.4.14 to 8.4.19
- Update libpng-dev from 1.6.55-r0 to 1.6.56-r0 to fix Alpine package compatibility

## Changes
- docker/php/Dockerfile.base: Updated PHP base image and libpng-dev version
- README.md: Updated supported containers documentation