### PR TITLE
fix: render podSecurityContext and securityContext in all workload templates

### DIFF
--- a/kubernetes/glpi/templates/glpi-cronjob.yaml
+++ b/kubernetes/glpi/templates/glpi-cronjob.yaml
@@ -14,11 +14,19 @@ spec:
   jobTemplate:
     spec:
       template:
-        spec:
-          containers:
-          - image: {{ include "glpi.phpfpm.image" . }}
+          spec:
+            {{- with .Values.glpi.podSecurityContext }}
+            securityContext:
+              {{- toYaml . | nindent 14 }}
+            {{- end }}
+            containers:
+            - image: {{ include "glpi.phpfpm.image" . }}
             imagePullPolicy: {{ .Values.glpi.phpfpm.image.pullPolicy }}
             name: base
+            {{- with .Values.glpi.securityContext }}
+            securityContext:
+              {{- toYaml . | nindent 14 }}
+            {{- end }}
             envFrom: 
             - configMapRef: 
                 name: glpi-config

--- a/kubernetes/glpi/templates/glpi-deployment.yaml
+++ b/kubernetes/glpi/templates/glpi-deployment.yaml
@@ -19,10 +19,18 @@ spec:
         {{- include "glpi.selectorLabels" . | nindent 8 }}
         app: php-fpm
     spec:
+      {{- with .Values.glpi.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
       - image: {{ include "glpi.phpfpm.image" . }}
         imagePullPolicy: {{ .Values.glpi.phpfpm.image.pullPolicy }}
         name: php
+        {{- with .Values.glpi.securityContext }}
+        securityContext:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
         envFrom: 
         - configMapRef: 
             name: glpi-config
@@ -91,10 +99,18 @@ spec:
         {{- include "glpi.selectorLabels" . | nindent 8 }}
         app: nginx
     spec:
+      {{- with .Values.glpi.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
       - image: {{ include "glpi.nginx.image" . }}
         imagePullPolicy: {{ .Values.glpi.nginx.image.pullPolicy }}
         name: nginx
+        {{- with .Values.glpi.securityContext }}
+        securityContext:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
         envFrom: 
         - configMapRef: 
             name: glpi-config

--- a/kubernetes/glpi/templates/glpi-job.yaml
+++ b/kubernetes/glpi/templates/glpi-job.yaml
@@ -10,18 +10,26 @@ metadata:
 spec:
   template:
     spec:
+      {{- with .Values.glpi.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
       - image: {{ include "glpi.phpfpm.image" . }}
         imagePullPolicy: {{ .Values.glpi.phpfpm.image.pullPolicy }}
         name: base
-        envFrom: 
-        - configMapRef: 
+        {{- with .Values.glpi.securityContext }}
+        securityContext:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
+        envFrom:
+        - configMapRef:
             name: glpi-config
-        - secretRef: 
+        - secretRef:
             name: glpi-secret
-        command: 
+        command:
         - sh
-        - -c 
+        - -c
         - "/usr/local/bin/glpi-verify-dir.sh"
         volumeMounts:
         - name: files 
@@ -59,12 +67,20 @@ metadata:
 spec:
   template:
     spec:
+      {{- with .Values.glpi.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
       - image: {{ include "glpi.phpfpm.image" . }}
         imagePullPolicy: {{ .Values.glpi.phpfpm.image.pullPolicy }}
         name: base
+        {{- with .Values.glpi.securityContext }}
+        securityContext:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
         command:
-        - sh 
+        - sh
         - -c
         - "/usr/local/bin/glpi-db-install.sh"
         envFrom: 
@@ -108,12 +124,20 @@ metadata:
 spec:
   template:
     spec:
+      {{- with .Values.glpi.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
       - image: {{ include "glpi.phpfpm.image" . }}
         imagePullPolicy: {{ .Values.glpi.phpfpm.image.pullPolicy }}
         name: base
+        {{- with .Values.glpi.securityContext }}
+        securityContext:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
         command:
-        - sh 
+        - sh
         - -c
         - "/usr/local/bin/glpi-db-upgrade.sh"
         envFrom: 
@@ -157,12 +181,20 @@ metadata:
 spec:
   template:
     spec:
+      {{- with .Values.glpi.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
       - image: {{ include "glpi.phpfpm.image" . }}
         imagePullPolicy: {{ .Values.glpi.phpfpm.image.pullPolicy }}
         name: base
+        {{- with .Values.glpi.securityContext }}
+        securityContext:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
         command:
-        - sh 
+        - sh
         - -c
         - "/usr/local/bin/glpi-db-configure.sh"
         envFrom: 
@@ -206,12 +238,20 @@ metadata:
 spec:
   template:
     spec:
+      {{- with .Values.glpi.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
       - image: {{ include "glpi.phpfpm.image" . }}
         imagePullPolicy: {{ .Values.glpi.phpfpm.image.pullPolicy }}
         name: base
+        {{- with .Values.glpi.securityContext }}
+        securityContext:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
         command:
-        - sh 
+        - sh
         - -c
         - "/usr/local/bin/glpi-cache-configure.sh"
         envFrom: 

--- a/kubernetes/glpi/templates/mariadb-job.yaml
+++ b/kubernetes/glpi/templates/mariadb-job.yaml
@@ -9,10 +9,18 @@ metadata:
 spec:
   template:
     spec:
+      {{- with .Values.mariadb.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
       - image: {{ include "glpi.mariadb.image" . }}
         imagePullPolicy: {{ .Values.mariadb.image.pullPolicy }}
         name: base
+        {{- with .Values.mariadb.securityContext }}
+        securityContext:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
         command:
         - sh
         - -c 

--- a/kubernetes/glpi/templates/mariadb-statefulset.yaml
+++ b/kubernetes/glpi/templates/mariadb-statefulset.yaml
@@ -25,6 +25,10 @@ spec:
         role: primary
       name: mariadb
     spec:
+      {{- with .Values.mariadb.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       affinity:
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
@@ -40,6 +44,10 @@ spec:
       containers:
       - image: {{ include "glpi.mariadb.image" . }}
         name: mariadb
+        {{- with .Values.mariadb.securityContext }}
+        securityContext:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
         imagePullPolicy: {{ .Values.mariadb.image.pullPolicy }}
         envFrom: 
         - secretRef: 

--- a/kubernetes/glpi/templates/redis-deployment.yaml
+++ b/kubernetes/glpi/templates/redis-deployment.yaml
@@ -18,8 +18,16 @@ spec:
         {{- include "glpi.selectorLabels" . | nindent 8 }}
         app: redis
     spec:
+      {{- with .Values.redis.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
       - name: redis
+        {{- with .Values.redis.securityContext }}
+        securityContext:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
         image: {{ include "glpi.redis.image" . }}
         imagePullPolicy: {{ .Values.redis.image.pullPolicy }}
         ports:

--- a/kubernetes/glpi/values.yaml
+++ b/kubernetes/glpi/values.yaml
@@ -197,6 +197,24 @@ glpi:
     # Schedule in cron format (default: every 2 minutes)
     schedule: "*/2 * * * *"
 
+  # -- GLPI Pod Security Context
+  # Security settings applied at the pod level
+  podSecurityContext:
+    # Set fsGroup to www-data (82) for file permissions
+    fsGroup: 82
+
+  # -- GLPI Container Security Context
+  # Security settings applied at the container level
+  securityContext:
+    # Run as non-root user
+    runAsNonRoot: true
+    # Run as www-data user (82)
+    runAsUser: 82
+    # Drop all capabilities
+    capabilities:
+      drop:
+      - ALL
+
 # -- MariaDB Database Configuration
 mariadb:
   # Enable or disable MariaDB deployment
@@ -255,6 +273,14 @@ mariadb:
     # Service port for database connections
     port: 3306
 
+  # -- MariaDB Pod Security Context
+  # Security settings applied at the pod level
+  podSecurityContext: {}
+
+  # -- MariaDB Container Security Context
+  # Security settings applied at the container level
+  securityContext: {}
+
 # -- Redis Cache Configuration
 redis:
   # Enable or disable Redis deployment
@@ -289,6 +315,14 @@ redis:
     # Service port for Redis connections
     port: 6379
 
+  # -- Redis Pod Security Context
+  # Security settings applied at the pod level
+  podSecurityContext: {}
+
+  # -- Redis Container Security Context
+  # Security settings applied at the container level
+  securityContext: {}
+
 # -- Ingress Configuration
 # Configure ingress to expose GLPI externally
 ingress:
@@ -315,24 +349,6 @@ ingress:
   #     hosts:
   #       - glpi.example.local
   tls: []
-
-# -- Pod Security Context
-# Security settings applied at the pod level
-podSecurityContext:
-  # Set fsGroup to www-data (33) for file permissions
-  fsGroup: 82
-
-# -- Container Security Context
-# Security settings applied at the container level
-securityContext:
-  # Run as non-root user
-  runAsNonRoot: true
-  # Run as www-data user (33)
-  runAsUser: 82
-  # Drop all capabilities
-  capabilities:
-    drop:
-    - ALL
 
 # -- Service Account Configuration
 serviceAccount:


### PR DESCRIPTION
## Problem

`values.yaml` declared `podSecurityContext` (fsGroup: 82) and `securityContext` (runAsUser: 82, non-root, drop ALL) but **no template referenced them**. All workloads landed with empty security contexts → kubelet didn't chown volumes → uid=82 couldn't write to PVCs → CrashLoopBackOff.

Fixes #153.

## Solution

Moved security contexts from global scope to per-component values and wired them into every workload template:

| Component | podSecurityContext | securityContext |
|-----------|-------------------|-----------------|
| glpi.* | ✓ fsGroup: 82 | ✓ runAsNonRoot, runAsUser: 82, drop ALL |
| mariadb.* | stub (`{}`) | stub (`{}`) |
| redis.* | stub (`{}`) | stub (`{}`) |

### Templates updated
- `glpi-deployment.yaml` — php-fpm + nginx (4 insertions)
- `glpi-job.yaml` — all 5 init jobs (10 insertions)
- `glpi-cronjob.yaml` — cronjob (2 insertions)
- `mariadb-statefulset.yaml` + `mariadb-job.yaml` (4 insertions)
- `redis-deployment.yaml` (2 insertions)

### Verification
- `helm lint` passes
- `helm template` renders: 8× fsGroup: 82, 8× runAsUser: 82 (php-fpm, nginx, 5 jobs, cronjob)
- MariaDB/Redis: empty `{}` renders nothing (no-op, users can override)