### PR TITLE
fix: gate Namespace creation behind `createNamespace` flag

### DIFF
--- a/kubernetes/glpi/templates/namespace.yaml
+++ b/kubernetes/glpi/templates/namespace.yaml
@@ -1,8 +1,8 @@
-{{- if .Values.global.namespace }}
+{{- if .Values.global.createNamespace }}
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: {{ .Values.global.namespace }}
+  name: {{ include "glpi.namespace" . }}
   labels:
     {{- include "glpi.labels" . | nindent 4 }}
 {{- end }}

--- a/kubernetes/glpi/values.yaml
+++ b/kubernetes/glpi/values.yaml
@@ -7,7 +7,11 @@ global:
   # Namespace where GLPI will be deployed
   # If not set, the release namespace will be used
   # Leave empty to use Helm's release namespace
-  namespace: "glpi"
+  namespace: ""
+  # Enable to create the Namespace resource (cluster-scoped)
+  # Set to true if your SA has cluster-wide permissions; leave false
+  # for namespace-scoped RBAC (e.g., FluxCD multi-tenancy)
+  createNamespace: false
 
 # -- GLPI Application Configuration
 glpi:


### PR DESCRIPTION
## Summary

Gate the Namespace resource behind a separate `global.createNamespace` boolean flag (defaults to `false`) instead of implicitly creating it when `global.namespace` is set.

## Problem

`templates/namespace.yaml` created a cluster-scoped `Namespace` object whenever `global.namespace` was non-empty (default: `"glpi"`). This broke namespace-scoped RBAC deployments (e.g., FluxCD multi-tenancy) where the ServiceAccount lacks cluster-wide permissions.

## Changes

- **`values.yaml`**: Default `namespace` changed to `""` (uses `.Release.Namespace`). Added `createNamespace: false` flag.
- **`templates/namespace.yaml`**: Gate changed to ```{{- if .Values.global.createNamespace }}```. Name uses `glpi.namespace` helper.
- The `glpi.namespace` helper in `_helpers.tpl` is unchanged — it already correctly resolves `global.namespace` → `.Release.Namespace`.

## Verification

- `helm lint`: 0 failures
- Default render: 0 Namespace objects
- `--set global.createNamespace=true`: 1 Namespace object rendered with correct name

## Migration

Users who relied on the default `namespace: "glpi"` to auto-create a Namespace must now set `global.createNamespace: true`.

Closes #154