### PR TITLE
fix: add role: primary selector to mariadb-headless service

### DIFF
--- a/kubernetes/glpi/templates/mariadb-statefulset.yaml
+++ b/kubernetes/glpi/templates/mariadb-statefulset.yaml
@@ -89,6 +89,7 @@ spec:
   publishNotReadyAddresses: true
   selector:
 {{ include "glpi.selectorLabels" . | indent 4 }}
+    role: primary
   sessionAffinity: None
   type: ClusterIP
 status:


### PR DESCRIPTION
Fixes #155

## Problem

The `mariadb-headless` headless service selector matched **all** pods in the release (nginx, php-fpm) because `glpi.selectorLabels` (`app.kubernetes.io/name` + `app.kubernetes.io/instance`) is applied chart-wide on every pod template.

This caused the headless service's DNS to round-robin across MariaDB, nginx, and php-fpm pod IPs — ~75% of connection attempts from GLPI to port 3306 would time out because nginx and php-fpm don't listen on that port.

## Fix

Added `role: primary` to the headless service selector, matching the pattern already used by the ClusterIP `mariadb` service (which correctly filtered to MariaDB pods only).

**Single line change** in `templates/mariadb-statefulset.yaml`:

```diff
   selector:
 {{ include "glpi.selectorLabels" . | indent 4 }}
+    role: primary
```

MariaDB StatefulSet pods already carry `role: primary` in their pod template labels, so the fix correctly restricts the headless service to only MariaDB endpoints.

## Verification

```bash
helm template test kubernetes/glpi/ --namespace test
```

Rendered headless service now has:

```yaml
selector:
  app.kubernetes.io/name: glpi
  app.kubernetes.io/instance: test
  role: primary
```