### PR TITLE
chore: consolidate Helm chart v11.0.7-1 fixes and CI improvements

### DIFF
--- a/.github/workflows/helm-publish.yaml
+++ b/.github/workflows/helm-publish.yaml
@@ -68,7 +68,7 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     needs: package
-    if: github.event.inputs.publish == 'true'
+    if: ${{ github.event_name == 'release' || github.event.inputs.publish == 'true' }}
     steps:
       - name: Check out repository code with full history
         uses: actions/checkout@v6

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,11 +2,12 @@
 
 ## Overview
 
-This repository contains Docker configurations for deploying GLPI (an IT asset management system). The project consists of:
+This repository contains Docker and Kubernetes configurations for deploying GLPI (an IT asset management system). The project consists of:
 - PHP-FPM base image (`docker/php/Dockerfile.base`)
 - PHP-FPM application image (`docker/php/Dockerfile`)
 - Nginx reverse proxy (`docker/nginx/Dockerfile`)
 - Docker Compose configurations for development and production
+- Helm chart for Kubernetes deployment (`kubernetes/glpi/`)
 
 ## Build Commands
 
@@ -19,8 +20,8 @@ docker-compose -f docker-compose-build.yml build
 
 # Build specific image
 docker build -t eftechcombr/glpi:base -f docker/php/Dockerfile.base docker/php/
-docker build -t eftechcombr/glpi:php-fpm-11.0.6 -f docker/php/Dockerfile docker/php/
-docker build -t eftechcombr/glpi:nginx-11.0.6 -f docker/nginx/Dockerfile docker/nginx/
+docker build -t eftechcombr/glpi:php-fpm-11.0.7 -f docker/php/Dockerfile docker/php/
+docker build -t eftechcombr/glpi:nginx-11.0.7 -f docker/nginx/Dockerfile docker/nginx/
 ```
 
 ### Run Containers
@@ -51,15 +52,17 @@ docker build --check docker/php/
 docker build --check docker/nginx/
 
 # Scan for secrets (via hadolint --secret)
-hadolint --secret支气管 docker/php/Dockerfile.base
+hadolint --secret docker/php/Dockerfile.base
 ```
+
+DeepSource is also configured for automated linting via `.deepsource.toml` (docker, secrets, and shell analyzers).
 
 ## Code Style Guidelines
 
 ### Dockerfiles
 
 #### General Rules
-- Use specific version tags for base images (e.g., `php:8.4.14-fpm-alpine3.22`, not `php:latest`)
+- Use specific version tags for base images (e.g., `php:8.4.19-fpm-alpine3.22`, not `php:latest`)
 - Pin package versions in Alpine (e.g., `icu-dev=76.1-r1`)
 - Always clean up build dependencies with `apk del .build-deps`
 - Remove `docker-php-source delete` after installing extensions
@@ -83,16 +86,16 @@ docker-php-ext-install intl mysqli gd exif bz2 zip ldap opcache bcmath
 ```
 
 #### Redis Extension
-Install via PECL with version pinning:
+Install via PECL (version pinning recommended for reproducible builds):
 ```dockerfile
-pecl install redis-6.2.0
+pecl install redis
 docker-php-ext-enable redis
 ```
 
 ### Docker Compose
 
 #### Version Tagging
-- Always use explicit version tags (e.g., `11.0.6`, not `latest`)
+- Always use explicit version tags (e.g., `11.0.7`, not `latest`)
 - Keep all service image tags synchronized
 - Use semantic versioning
 
@@ -162,11 +165,11 @@ trap 'echo "Error on line $LINENO"' ERR
 ### Images
 - Lowercase: `eftechcombr/glpi`
 - Use kebab-case: `php-fpm`, `nginx`
-- Version format: `11.0.6`
+- Version format: `11.0.7`
 
 ### Services (docker-compose)
 - Lowercase with hyphens: `mariadb`, `glpi-db-install`
-- Descriptive: `glpi-db-configure`, `glpi-cache-configure`
+- Descriptive: `glpi-db-configure`, `glpi-cache-configure`, `glpi-verify-dir`, `glpi-db-upgrade`, `mariadb-timezone`
 
 ### Environment Variables
 - Uppercase with underscores: `MARIADB_HOST`, `GLPI_VERSION`
@@ -177,7 +180,7 @@ trap 'echo "Error on line $LINENO"' ERR
 When upgrading GLPI or PHP versions:
 
 1. Update `docker/php/Dockerfile.base`:
-   - PHP version (e.g., `8.4.13` → `8.4.14`)
+   - PHP version (e.g., `8.4.13` → `8.4.19`)
    - Alpine version if needed
    - All pinned package versions (verify they exist in Alpine)
 
@@ -187,23 +190,32 @@ When upgrading GLPI or PHP versions:
 3. Update `docker/.env`:
    - `VERSION="11.0.x"`
 
-4. Update `docker/docker-compose.yml`:
+4. Update `docker/.env.example`:
+   - `VERSION="11.0.x"`
+
+5. Update `docker/docker-compose.yml`:
    - All image tags
 
-5. Update `docker/docker-compose-build.yml`:
+6. Update `docker/docker-compose-build.yml`:
    - All image tags
 
-6. Update `docker/nginx/Dockerfile`:
+7. Update `docker/nginx/Dockerfile`:
    - Base image tag
 
-7. Verify with hadolint:
+8. Update `kubernetes/glpi/Chart.yaml`:
+   - `version:` and `appVersion:` fields
+
+9. Update `kubernetes/glpi/values.yaml`:
+   - `glpi.version`, `glpi.phpfpm.image.tag`, `glpi.nginx.image.tag`
+
+10. Verify with hadolint:
    ```bash
    hadolint docker/php/Dockerfile.base
    hadolint docker/php/Dockerfile
    hadolint docker/nginx/Dockerfile
    ```
 
-8. Test build locally:
+11. Test build locally:
    ```bash
    cd docker
    docker-compose -f docker-compose-build.yml build base
@@ -215,10 +227,10 @@ Current pinned versions in `Dockerfile.base` (Alpine 3.22):
 
 | Package | Version |
 |---------|---------|
-| php base | 8.4.14-fpm-alpine3.22 |
+| php base | 8.4.19-fpm-alpine3.22 |
 | icu-dev | 76.1-r1 |
-| zlib-dev | 1.3.1-r2 |
-| libpng-dev | 1.6.55-r0 |
+| zlib-dev | 1.3.2-r0 |
+| libpng-dev | 1.6.57-r0 |
 | bzip2-dev | 1.0.8-r6 |
 | libzip-dev | 1.11.4-r0 |
 | openldap-dev | 2.6.8-r0 |
@@ -228,7 +240,7 @@ Current pinned versions in `Dockerfile.base` (Alpine 3.22):
 | file | 5.46-r2 |
 | g++ | 14.2.0-r6 |
 | gcc | 14.2.0-r6 |
-| musl-dev | 1.2.5-r10 |
+| musl-dev | 1.2.5-r12 |
 | make | 4.4.1-r3 |
 | pkgconf | 2.4.3-r0 |
 | re2c | 4.2-r0 |

--- a/README.md
+++ b/README.md
@@ -8,9 +8,9 @@ Manifest files for building and deploying **GLPI** using containers with Docker 
 ## Supported Containers
 
 - [x] PHP-FPM: `php:8.4.19-fpm-alpine3.22`
-- [x] Nginx: `nginxinc/nginx-unprivileged:1.29.1-alpine3.22-slim`
-- [x] GLPI PHP: `eftechcombr/glpi:php-fpm-11.0.6`
-- [x] GLPI Nginx: `eftechcombr/glpi:nginx-11.0.6`
+- [x] Nginx: `nginxinc/nginx-unprivileged:1.27.5-alpine3.21-slim`
+- [x] GLPI PHP: `eftechcombr/glpi:php-fpm-11.0.7`
+- [x] GLPI Nginx: `eftechcombr/glpi:nginx-11.0.7`
 
 ## Quick Start
 
@@ -64,7 +64,14 @@ helm uninstall my-glpi
 2. Set up environment variables:
 ```sh
 cp docker/.env.example docker/.env
+# Edit docker/.env with your desired configuration
 ```
+3. Start the containers:
+```sh
+cd docker
+docker compose up -d
+```
+GLPI will be accessible at http://localhost:8080
 
 ## Credentials
 
@@ -75,7 +82,12 @@ cp docker/.env.example docker/.env
 
 ### docker-compose 
 
-    ./docker/_env ---> please rename to /docker/.env
+    ./docker/.env.example ---> copy to ./docker/.env and customize
+
+    See ./docker/.env for available environment variables including:
+    - MARIADB_HOST, MARIADB_PORT, MARIADB_DATABASE, MARIADB_USER, MARIADB_PASSWORD
+    - GLPI_LANG, VERSION, CACHE_DSN
+    - GLPI_VAR_DIR, GLPI_CONFIG_DIR, GLPI_MARKETPLACE_DIR and other directory paths
 
 
 ### kubernetes

--- a/docker/.env.example
+++ b/docker/.env.example
@@ -1,5 +1,5 @@
 GLPI_LANG="en_US"
-VERSION="11.0.5"
+VERSION="11.0.7"
 GLPI_MARKETPLACE_DIR=/var/www/html/marketplace
 GLPI_VAR_DIR=/var/lib/glpi
 GLPI_DOC_DIR=/var/lib/glpi

--- a/kubernetes/glpi/Chart.yaml
+++ b/kubernetes/glpi/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: glpi
 description: GLPI Helm Chart - IT Asset Management and Service Desk
 type: application
-version: 11.0.7
+version: 11.0.7-1
 appVersion: "11.0.7"
 
 # Artifact Hub Metadata
@@ -32,5 +32,29 @@ annotations:
     - name: support
       url: https://github.com/eftechcombr/glpi/issues
   artifacthub.io/changes: |
+    - kind: fixed
+      description: "Fix CronJob YAML indentation bug preventing deployment"
+    - kind: fixed
+      description: "Fix Ingress backend service name to match nginx service"
+    - kind: changed
+      description: "StatefulSet now uses volumeClaimTemplates for multi-replica support"
+    - kind: changed
+      description: "Use app.kubernetes.io/component labels consistently across all templates"
     - kind: added
-      description: "Initial release of GLPI 11.0.7 Helm Chart"
+      description: "ServiceAccount template with imagePullSecrets and scheduling values"
+    - kind: added
+      description: "External database support via externalDatabase config"
+    - kind: changed
+      description: "Added security contexts and resource limits to init containers"
+    - kind: changed
+      description: "Redis now has liveness/readiness probes and security context defaults"
+    - kind: changed
+      description: "MariaDB and Redis now run with non-root security contexts by default"
+    - kind: fixed
+      description: "Fix GLPI_DOC_DIR pointing to /var/www/html instead of var dir"
+    - kind: changed
+      description: "StatefulSet anti-affinity changed to requiredDuringScheduling"
+    - kind: fixed
+      description: "Remove deprecated alpha API annotation and status subresource fields"
+    - kind: added
+      description: "Added terminationGracePeriodSeconds to MariaDB StatefulSet"

--- a/kubernetes/glpi/README.md
+++ b/kubernetes/glpi/README.md
@@ -83,4 +83,6 @@ All components are configured with secure defaults:
 
 ---
 
+---
+
 *Developed by [EFTech](https://eftech.com.br)*

--- a/kubernetes/glpi/README.md
+++ b/kubernetes/glpi/README.md
@@ -46,7 +46,41 @@ If using multiple replicas for PHP-FPM, ensure your StorageClass supports `ReadW
 
 ## Database
 
-By default, the chart deploys MariaDB. For production, it is recommended to use an external database by setting `mariadb.enabled: false` and providing connection details in `glpi.jobs.dbConfigure`.
+By default, the chart deploys MariaDB. For production, it is recommended to use an external database by setting `mariadb.enabled: false` and providing connection details via the `externalDatabase` section:
+
+```yaml
+mariadb:
+  enabled: false
+
+externalDatabase:
+  host: my-db-host.example.com
+  database: glpi
+  username: glpi
+  password: mySecurePassword
+```
+
+## Initialization Jobs
+
+The chart includes Helm hook jobs that run during install/upgrade:
+
+| Job | Hook | Weight | Description |
+|-----|------|--------|-------------|
+| `glpi-verify-dir` | post-install, post-upgrade | 5 | Create required GLPI directories |
+| `mariadb-timezone` | post-install, post-upgrade | 7 | Populate MariaDB timezone data |
+| `glpi-db-install` | post-install | 10 | Install GLPI database schema (fresh installs) |
+| `glpi-db-upgrade` | post-upgrade | 10 | Upgrade GLPI database schema (upgrades) |
+| `glpi-db-configure` | post-install, post-upgrade | 20 | Configure GLPI database connection |
+| `glpi-cache-configure` | post-install, post-upgrade | 30 | Configure GLPI Redis cache settings |
+
+Jobs can be individually disabled via `glpi.jobs.<name>.enabled: false`.
+
+## Security Contexts
+
+All components are configured with secure defaults:
+- **GLPI (PHP-FPM/Nginx)**: Runs as non-root user `www-data` (uid 82), drops all capabilities
+- **MariaDB**: Runs as non-root user (uid 1001) with `fsGroup: 1001`
+- **Redis**: Runs as non-root user (uid 999) with `fsGroup: 1001`
 
 ---
+
 *Developed by [EFTech](https://eftech.com.br)*

--- a/kubernetes/glpi/templates/_helpers.tpl
+++ b/kubernetes/glpi/templates/_helpers.tpl
@@ -52,10 +52,17 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 Return the proper namespace
 */}}
 {{- define "glpi.namespace" -}}
-{{- if .Values.global }}
 {{- .Values.global.namespace | default .Release.Namespace }}
+{{- end }}
+
+{{/*
+Return the service account name
+*/}}
+{{- define "glpi.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- .Values.serviceAccount.name | default (include "glpi.fullname" .) }}
 {{- else }}
-{{- .Release.Namespace }}
+{{- .Values.serviceAccount.name | default "default" }}
 {{- end }}
 {{- end }}
 

--- a/kubernetes/glpi/templates/glpi-configmap.yaml
+++ b/kubernetes/glpi/templates/glpi-configmap.yaml
@@ -1,16 +1,16 @@
 apiVersion: v1
 kind: ConfigMap
-metadata: 
+metadata:
   name: glpi-config
   namespace: {{ include "glpi.namespace" . }}
   labels:
     {{- include "glpi.labels" . | nindent 4 }}
-data: 
+data:
   GLPI_LANG: {{ .Values.glpi.language | quote }}
   VERSION: {{ .Values.glpi.version | quote }}
   GLPI_MARKETPLACE_DIR: {{ .Values.glpi.paths.marketplace }}
   GLPI_VAR_DIR: {{ .Values.glpi.paths.var }}
-  GLPI_DOC_DIR: {{ .Values.glpi.paths.var }}
+  GLPI_DOC_DIR: /var/www/html
   GLPI_CRON_DIR: {{ .Values.glpi.paths.var }}/_cron
   GLPI_DUMP_DIR: {{ .Values.glpi.paths.var }}/_dumps
   GLPI_GRAPH_DIR: {{ .Values.glpi.paths.var }}/_graphs
@@ -18,18 +18,22 @@ data:
   GLPI_LOG_DIR: {{ .Values.glpi.paths.var }}/_log
   GLPI_PICTURE_DIR: {{ .Values.glpi.paths.var }}/_pictures
   GLPI_PLUGIN_DOC_DIR: {{ .Values.glpi.paths.var }}/_plugins
-  GLPI_RSS_DIR:  {{ .Values.glpi.paths.var }}/_rss
+  GLPI_RSS_DIR: {{ .Values.glpi.paths.var }}/_rss
   GLPI_SESSION_DIR: {{ .Values.glpi.paths.var }}/_sessions
   GLPI_TMP_DIR: {{ .Values.glpi.paths.var }}/_tmp
   GLPI_UPLOAD_DIR: {{ .Values.glpi.paths.var }}/_uploads
   GLPI_CACHE_DIR: {{ .Values.glpi.paths.var }}/_cache
   GLPI_CONFIG_DIR: {{ .Values.glpi.paths.config }}
 
+  {{- if .Values.mariadb.enabled }}
   MARIADB_HOST: "mariadb-headless.{{ include "glpi.namespace" . }}.svc.cluster.local"
+  {{- else if .Values.externalDatabase }}
+  MARIADB_HOST: {{ .Values.externalDatabase.host | quote }}
+  {{- end }}
   MARIADB_PORT: {{ .Values.mariadb.service.port | quote }}
 
 
---- 
+---
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -37,28 +41,27 @@ metadata:
   namespace: {{ include "glpi.namespace" . }}
   labels:
     {{- include "glpi.labels" . | nindent 4 }}
-    name: nginx-conf 
+    name: nginx-conf
 data:
   default.conf: |-
     server {
         listen 8080;
         listen [::]:8080;
-        
+
         server_name glpi.localhost;
-        
+
         root /var/www/html/public;
-        
+
         location / {
             try_files $uri /index.php$is_args$args;
         }
-        
+
         location ~ ^/index\.php$ {
-            # the following line needs to be adapted, as it changes depending on OS distributions and PHP versions
             fastcgi_pass php-fpm.{{ include "glpi.namespace" . }}.svc.cluster.local:9000;
-            
+
             fastcgi_split_path_info ^(.+\.php)(/.*)$;
             include fastcgi_params;
-            
+
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
         }
     }

--- a/kubernetes/glpi/templates/glpi-cronjob.yaml
+++ b/kubernetes/glpi/templates/glpi-cronjob.yaml
@@ -1,4 +1,4 @@
-{{- if not (hasKey .Values.glpi.cronjob "enabled") | or .Values.glpi.cronjob.enabled }}
+{{- if .Values.glpi.cronjob.enabled }}
 apiVersion: batch/v1
 kind: CronJob
 metadata:
@@ -14,44 +14,61 @@ spec:
   jobTemplate:
     spec:
       template:
-          spec:
-            {{- with .Values.glpi.podSecurityContext }}
-            securityContext:
-              {{- toYaml . | nindent 14 }}
-            {{- end }}
-            containers:
+        spec:
+          {{- with .Values.imagePullSecrets }}
+          imagePullSecrets:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.glpi.podSecurityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.nodeSelector }}
+          nodeSelector:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.tolerations }}
+          tolerations:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.affinity }}
+          affinity:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          containers:
             - image: {{ include "glpi.phpfpm.image" . }}
-            imagePullPolicy: {{ .Values.glpi.phpfpm.image.pullPolicy }}
-            name: base
-            {{- with .Values.glpi.securityContext }}
-            securityContext:
-              {{- toYaml . | nindent 14 }}
-            {{- end }}
-            envFrom: 
-            - configMapRef: 
-                name: glpi-config
-            - secretRef: 
-                name: glpi-secret
-            command: 
-            - php
-            - front/cron.php
-            volumeMounts:
-            - name: files 
-              mountPath: /var/lib/glpi
-            - name: marketplace
-              mountPath: /var/www/html/marketplace
-            - name: etc 
-              mountPath: /etc/glpi
+              imagePullPolicy: {{ .Values.glpi.phpfpm.image.pullPolicy }}
+              name: base
+              {{- with .Values.glpi.securityContext }}
+              securityContext:
+                {{- toYaml . | nindent 16 }}
+              {{- end }}
+              envFrom: 
+                - configMapRef: 
+                    name: glpi-config
+                - secretRef: 
+                    name: glpi-secret
+              command: 
+                - php
+                - front/cron.php
+              volumeMounts:
+                - name: files 
+                  mountPath: /var/lib/glpi
+                - name: marketplace
+                  mountPath: /var/www/html/marketplace
+                - name: etc 
+                  mountPath: /etc/glpi
+              resources:
+                {{- toYaml .Values.glpi.phpfpm.resources | nindent 16 }}
           volumes: 
-          - name: etc
-            persistentVolumeClaim:
-              claimName: glpi-etc      
-          - name: files
-            persistentVolumeClaim:
-              claimName: glpi-files
-          - name: marketplace
-            persistentVolumeClaim:
-              claimName: glpi-marketplace
+            - name: etc
+              persistentVolumeClaim:
+                claimName: glpi-etc
+            - name: files
+              persistentVolumeClaim:
+                claimName: glpi-files
+            - name: marketplace
+              persistentVolumeClaim:
+                claimName: glpi-marketplace
           restartPolicy: OnFailure
 {{- end }}
-

--- a/kubernetes/glpi/templates/glpi-deployment.yaml
+++ b/kubernetes/glpi/templates/glpi-deployment.yaml
@@ -1,81 +1,105 @@
---- 
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: php-fpm
   labels:
     {{- include "glpi.labels" . | nindent 4 }}
-    app: php-fpm
+    app.kubernetes.io/component: php-fpm
   namespace: {{ include "glpi.namespace" . }}
 spec:
   replicas: {{ .Values.glpi.phpfpm.replicaCount }}
   selector:
     matchLabels:
       {{- include "glpi.selectorLabels" . | nindent 6 }}
-      app: php-fpm
+      app.kubernetes.io/component: php-fpm
   template:
     metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       labels:
         {{- include "glpi.selectorLabels" . | nindent 8 }}
-        app: php-fpm
+        app.kubernetes.io/component: php-fpm
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
     spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "glpi.serviceAccountName" . }}
       {{- with .Values.glpi.podSecurityContext }}
       securityContext:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
-      - image: {{ include "glpi.phpfpm.image" . }}
-        imagePullPolicy: {{ .Values.glpi.phpfpm.image.pullPolicy }}
-        name: php
-        {{- with .Values.glpi.securityContext }}
-        securityContext:
-          {{- toYaml . | nindent 10 }}
-        {{- end }}
-        envFrom: 
-        - configMapRef: 
-            name: glpi-config
-        - secretRef: 
-            name: glpi-secret
-        ports:
-        - containerPort: 9000
-          name: fpm
-        volumeMounts:
-        - name: files 
-          mountPath: /var/lib/glpi
-        - name: etc 
-          mountPath: /etc/glpi
+        - image: {{ include "glpi.phpfpm.image" . }}
+          imagePullPolicy: {{ .Values.glpi.phpfpm.image.pullPolicy }}
+          name: php
+          {{- with .Values.glpi.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          envFrom:
+            - configMapRef:
+                name: glpi-config
+            - secretRef:
+                name: glpi-secret
+          ports:
+            - containerPort: 9000
+              name: fpm
+          volumeMounts:
+            - name: files
+              mountPath: /var/lib/glpi
+            - name: etc
+              mountPath: /etc/glpi
+            - name: marketplace
+              mountPath: /var/www/html/marketplace
+          {{- if .Values.glpi.phpfpm.livenessProbe.enabled }}
+          livenessProbe:
+            tcpSocket:
+              port: {{ .Values.glpi.phpfpm.livenessProbe.tcpSocket.port }}
+            initialDelaySeconds: {{ .Values.glpi.phpfpm.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.glpi.phpfpm.livenessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.glpi.phpfpm.livenessProbe.timeoutSeconds }}
+            failureThreshold: {{ .Values.glpi.phpfpm.livenessProbe.failureThreshold }}
+          {{- end }}
+          {{- if .Values.glpi.phpfpm.readinessProbe.enabled }}
+          readinessProbe:
+            tcpSocket:
+              port: {{ .Values.glpi.phpfpm.readinessProbe.tcpSocket.port }}
+            initialDelaySeconds: {{ .Values.glpi.phpfpm.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.glpi.phpfpm.readinessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.glpi.phpfpm.readinessProbe.timeoutSeconds }}
+            failureThreshold: {{ .Values.glpi.phpfpm.readinessProbe.failureThreshold }}
+          {{- end }}
+          resources:
+            {{- toYaml .Values.glpi.phpfpm.resources | nindent 12 }}
+      volumes:
+        - name: etc
+          persistentVolumeClaim:
+            claimName: glpi-etc
+        - name: files
+          persistentVolumeClaim:
+            claimName: glpi-files
         - name: marketplace
-          mountPath: /var/www/html/marketplace
-        {{- if .Values.glpi.phpfpm.livenessProbe.enabled }}
-        livenessProbe:
-          tcpSocket:
-            port: {{ .Values.glpi.phpfpm.livenessProbe.tcpSocket.port }}
-          initialDelaySeconds: {{ .Values.glpi.phpfpm.livenessProbe.initialDelaySeconds }}
-          periodSeconds: {{ .Values.glpi.phpfpm.livenessProbe.periodSeconds }}
-          timeoutSeconds: {{ .Values.glpi.phpfpm.livenessProbe.timeoutSeconds }}
-          failureThreshold: {{ .Values.glpi.phpfpm.livenessProbe.failureThreshold }}
-        {{- end }}
-        {{- if .Values.glpi.phpfpm.readinessProbe.enabled }}
-        readinessProbe:
-          tcpSocket:
-            port: {{ .Values.glpi.phpfpm.readinessProbe.tcpSocket.port }}
-          initialDelaySeconds: {{ .Values.glpi.phpfpm.readinessProbe.initialDelaySeconds }}
-          periodSeconds: {{ .Values.glpi.phpfpm.readinessProbe.periodSeconds }}
-          timeoutSeconds: {{ .Values.glpi.phpfpm.readinessProbe.timeoutSeconds }}
-          failureThreshold: {{ .Values.glpi.phpfpm.readinessProbe.failureThreshold }}
-        {{- end }}
-        resources:
-          {{- toYaml .Values.glpi.phpfpm.resources | nindent 10 }}
-      volumes: 
-      - name: etc 
-        persistentVolumeClaim: 
-          claimName: glpi-etc 
-      - name: files
-        persistentVolumeClaim:
-          claimName: glpi-files
-      - name: marketplace
-        persistentVolumeClaim:
-          claimName: glpi-marketplace
+          persistentVolumeClaim:
+            claimName: glpi-marketplace
 
 
 ---
@@ -85,121 +109,144 @@ metadata:
   name: nginx
   labels:
     {{- include "glpi.labels" . | nindent 4 }}
-    app: nginx
+    app.kubernetes.io/component: nginx
   namespace: {{ include "glpi.namespace" . }}
 spec:
   replicas: {{ .Values.glpi.nginx.replicaCount }}
   selector:
     matchLabels:
       {{- include "glpi.selectorLabels" . | nindent 6 }}
-      app: nginx
+      app.kubernetes.io/component: nginx
   template:
     metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       labels:
         {{- include "glpi.selectorLabels" . | nindent 8 }}
-        app: nginx
+        app.kubernetes.io/component: nginx
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
     spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "glpi.serviceAccountName" . }}
       {{- with .Values.glpi.podSecurityContext }}
       securityContext:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
-      - image: {{ include "glpi.nginx.image" . }}
-        imagePullPolicy: {{ .Values.glpi.nginx.image.pullPolicy }}
-        name: nginx
-        {{- with .Values.glpi.securityContext }}
-        securityContext:
-          {{- toYaml . | nindent 10 }}
-        {{- end }}
-        envFrom: 
-        - configMapRef: 
-            name: glpi-config
-        - secretRef: 
-            name: glpi-secret
-        ports:
-        - containerPort: 8080
-          name: http
-        volumeMounts:
-        - name: files 
-          mountPath: /var/lib/glpi
-        - name: marketplace
-          mountPath: /var/www/html/marketplace
+        - image: {{ include "glpi.nginx.image" . }}
+          imagePullPolicy: {{ .Values.glpi.nginx.image.pullPolicy }}
+          name: nginx
+          {{- with .Values.glpi.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          envFrom:
+            - configMapRef:
+                name: glpi-config
+            - secretRef:
+                name: glpi-secret
+          ports:
+            - containerPort: 8080
+              name: http
+          volumeMounts:
+            - name: files
+              mountPath: /var/lib/glpi
+            - name: marketplace
+              mountPath: /var/www/html/marketplace
+            - name: etc
+              mountPath: /etc/glpi
+            - name: nginx-conf
+              mountPath: /etc/nginx/conf.d
+          {{- if .Values.glpi.nginx.livenessProbe.enabled }}
+          livenessProbe:
+            httpGet:
+              path: {{ .Values.glpi.nginx.livenessProbe.httpGet.path }}
+              port: {{ .Values.glpi.nginx.livenessProbe.httpGet.port }}
+            initialDelaySeconds: {{ .Values.glpi.nginx.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.glpi.nginx.livenessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.glpi.nginx.livenessProbe.timeoutSeconds }}
+            failureThreshold: {{ .Values.glpi.nginx.livenessProbe.failureThreshold }}
+          {{- end }}
+          {{- if .Values.glpi.nginx.readinessProbe.enabled }}
+          readinessProbe:
+            httpGet:
+              path: {{ .Values.glpi.nginx.readinessProbe.httpGet.path }}
+              port: {{ .Values.glpi.nginx.readinessProbe.httpGet.port }}
+            initialDelaySeconds: {{ .Values.glpi.nginx.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.glpi.nginx.readinessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.glpi.nginx.readinessProbe.timeoutSeconds }}
+            failureThreshold: {{ .Values.glpi.nginx.readinessProbe.failureThreshold }}
+          {{- end }}
+          resources:
+            {{- toYaml .Values.glpi.nginx.resources | nindent 12 }}
+      volumes:
         - name: etc
-          mountPath: /etc/glpi
+          persistentVolumeClaim:
+            claimName: glpi-etc
+        - name: files
+          persistentVolumeClaim:
+            claimName: glpi-files
+        - name: marketplace
+          persistentVolumeClaim:
+            claimName: glpi-marketplace
         - name: nginx-conf
-          mountPath: /etc/nginx/conf.d
-        {{- if .Values.glpi.nginx.livenessProbe.enabled }}
-        livenessProbe:
-          httpGet:
-            path: {{ .Values.glpi.nginx.livenessProbe.httpGet.path }}
-            port: {{ .Values.glpi.nginx.livenessProbe.httpGet.port }}
-          initialDelaySeconds: {{ .Values.glpi.nginx.livenessProbe.initialDelaySeconds }}
-          periodSeconds: {{ .Values.glpi.nginx.livenessProbe.periodSeconds }}
-          timeoutSeconds: {{ .Values.glpi.nginx.livenessProbe.timeoutSeconds }}
-          failureThreshold: {{ .Values.glpi.nginx.livenessProbe.failureThreshold }}
-        {{- end }}
-        {{- if .Values.glpi.nginx.readinessProbe.enabled }}
-        readinessProbe:
-          httpGet:
-            path: {{ .Values.glpi.nginx.readinessProbe.httpGet.path }}
-            port: {{ .Values.glpi.nginx.readinessProbe.httpGet.port }}
-          initialDelaySeconds: {{ .Values.glpi.nginx.readinessProbe.initialDelaySeconds }}
-          periodSeconds: {{ .Values.glpi.nginx.readinessProbe.periodSeconds }}
-          timeoutSeconds: {{ .Values.glpi.nginx.readinessProbe.timeoutSeconds }}
-          failureThreshold: {{ .Values.glpi.nginx.readinessProbe.failureThreshold }}
-        {{- end }}
-        resources:
-          {{- toYaml .Values.glpi.nginx.resources | nindent 10 }}
-      volumes: 
-      - name: etc 
-        persistentVolumeClaim:
-          claimName: glpi-etc 
-      - name: files
-        persistentVolumeClaim:
-          claimName: glpi-files
-      - name: marketplace
-        persistentVolumeClaim:
-          claimName: glpi-marketplace          
-      - name: nginx-conf
-        configMap:
-          defaultMode: 420
-          name: nginx-conf
+          configMap:
+            defaultMode: 420
+            name: nginx-conf
 
 
---- 
+---
 apiVersion: v1
 kind: Service
-metadata: 
+metadata:
   name: php-fpm
   labels:
     {{- include "glpi.labels" . | nindent 4 }}
-    app: php-fpm
+    app.kubernetes.io/component: php-fpm
   namespace: {{ include "glpi.namespace" . }}
 spec:
-  ports: 
+  type: ClusterIP
+  ports:
     - port: 9000
       targetPort: 9000
   selector:
     {{- include "glpi.selectorLabels" . | nindent 4 }}
-    app: php-fpm
+    app.kubernetes.io/component: php-fpm
 
 
---- 
+---
 apiVersion: v1
 kind: Service
-metadata: 
+metadata:
   name: nginx
   labels:
     {{- include "glpi.labels" . | nindent 4 }}
-    app: nginx
+    app.kubernetes.io/component: nginx
   namespace: {{ include "glpi.namespace" . }}
 spec:
   type: {{ .Values.glpi.nginx.service.type }}
-  ports: 
+  ports:
     - port: {{ .Values.glpi.nginx.service.port }}
       targetPort: {{ .Values.glpi.nginx.service.targetPort }}
   selector:
     {{- include "glpi.selectorLabels" . | nindent 4 }}
-    app: nginx
-
-
+    app.kubernetes.io/component: nginx

--- a/kubernetes/glpi/templates/glpi-ingress.yaml
+++ b/kubernetes/glpi/templates/glpi-ingress.yaml
@@ -34,7 +34,7 @@ spec:
             pathType: {{ .pathType }}
             backend:
               service:
-                name: {{ include "glpi.fullname" $ }}-nginx
+                name: nginx
                 port:
                   number: {{ $.Values.glpi.nginx.service.port }}
           {{- end }}

--- a/kubernetes/glpi/templates/glpi-job.yaml
+++ b/kubernetes/glpi/templates/glpi-job.yaml
@@ -7,6 +7,7 @@ metadata:
   namespace: {{ include "glpi.namespace" . }}
   labels:
     {{- include "glpi.labels" . | nindent 4 }}
+    app.kubernetes.io/component: job
   annotations:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-weight": "5"
@@ -14,48 +15,52 @@ metadata:
 spec:
   template:
     spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "glpi.serviceAccountName" . }}
       {{- with .Values.glpi.podSecurityContext }}
       securityContext:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       containers:
-      - image: {{ include "glpi.phpfpm.image" . }}
-        imagePullPolicy: {{ .Values.glpi.phpfpm.image.pullPolicy }}
-        name: base
-        {{- with .Values.glpi.securityContext }}
-        securityContext:
-          {{- toYaml . | nindent 10 }}
-        {{- end }}
-        envFrom:
-        - configMapRef:
-            name: glpi-config
-        - secretRef:
-            name: glpi-secret
-        command:
-        - sh
-        - -c
-        - "/usr/local/bin/glpi-verify-dir.sh"
-        volumeMounts:
-        - name: files
-          mountPath: /var/lib/glpi
-        - name: marketplace
-          mountPath: /var/www/html/marketplace
-        - name: etc
-          mountPath: /etc/glpi
+        - image: {{ include "glpi.phpfpm.image" . }}
+          imagePullPolicy: {{ .Values.glpi.phpfpm.image.pullPolicy }}
+          name: base
+          {{- with .Values.glpi.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          envFrom:
+            - configMapRef:
+                name: glpi-config
+            - secretRef:
+                name: glpi-secret
+          command:
+            - sh
+            - -c
+            - "/usr/local/bin/glpi-verify-dir.sh"
+          volumeMounts:
+            - name: files
+              mountPath: /var/lib/glpi
+            - name: marketplace
+              mountPath: /var/www/html/marketplace
+            - name: etc
+              mountPath: /etc/glpi
       volumes:
-      - name: etc
-        persistentVolumeClaim:
-          claimName: glpi-etc
-      - name: files
-        persistentVolumeClaim:
-          claimName: glpi-files
-      - name: marketplace
-        persistentVolumeClaim:
-          claimName: glpi-marketplace
+        - name: etc
+          persistentVolumeClaim:
+            claimName: glpi-etc
+        - name: files
+          persistentVolumeClaim:
+            claimName: glpi-files
+        - name: marketplace
+          persistentVolumeClaim:
+            claimName: glpi-marketplace
       restartPolicy: OnFailure
   parallelism: 1
   completions: 1
-status: {}
 {{- end }}
 
 
@@ -68,6 +73,7 @@ metadata:
   namespace: {{ include "glpi.namespace" . }}
   labels:
     {{- include "glpi.labels" . | nindent 4 }}
+    app.kubernetes.io/component: job
   annotations:
     "helm.sh/hook": post-install
     "helm.sh/hook-weight": "10"
@@ -75,58 +81,75 @@ metadata:
 spec:
   template:
     spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "glpi.serviceAccountName" . }}
       {{- with .Values.glpi.podSecurityContext }}
       securityContext:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       initContainers:
-      - name: wait-for-mariadb
-        image: busybox:1.36.1
-        command:
-        - sh
-        - -c
-        - until nc -z $MARIADB_HOST $MARIADB_PORT; do sleep 2; done
-        envFrom:
-        - configMapRef:
-            name: mariadb-glpi-config
+        - name: wait-for-mariadb
+          image: busybox:1.36.1
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 65534
+            capabilities:
+              drop:
+                - ALL
+          command:
+            - sh
+            - -c
+            - until nc -z $MARIADB_HOST $MARIADB_PORT; do sleep 2; done
+          envFrom:
+            - configMapRef:
+                name: mariadb-glpi-config
+          resources:
+            limits:
+              cpu: 100m
+              memory: 64Mi
+            requests:
+              cpu: 50m
+              memory: 32Mi
       containers:
-      - image: {{ include "glpi.phpfpm.image" . }}
-        imagePullPolicy: {{ .Values.glpi.phpfpm.image.pullPolicy }}
-        name: base
-        {{- with .Values.glpi.securityContext }}
-        securityContext:
-          {{- toYaml . | nindent 10 }}
-        {{- end }}
-        command:
-        - sh
-        - -c
-        - "/usr/local/bin/glpi-db-install.sh"
-        envFrom:
-        - configMapRef:
-            name: glpi-config
-        - secretRef:
-            name: glpi-secret
-        volumeMounts:
-        - name: files
-          mountPath: /var/lib/glpi
-        - name: marketplace
-          mountPath: /var/www/html/marketplace
-        - name: etc
-          mountPath: /etc/glpi
+        - image: {{ include "glpi.phpfpm.image" . }}
+          imagePullPolicy: {{ .Values.glpi.phpfpm.image.pullPolicy }}
+          name: base
+          {{- with .Values.glpi.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          command:
+            - sh
+            - -c
+            - "/usr/local/bin/glpi-db-install.sh"
+          envFrom:
+            - configMapRef:
+                name: glpi-config
+            - secretRef:
+                name: glpi-secret
+          volumeMounts:
+            - name: files
+              mountPath: /var/lib/glpi
+            - name: marketplace
+              mountPath: /var/www/html/marketplace
+            - name: etc
+              mountPath: /etc/glpi
       volumes:
-      - name: etc
-        persistentVolumeClaim:
-          claimName: glpi-etc
-      - name: files
-        persistentVolumeClaim:
-          claimName: glpi-files
-      - name: marketplace
-        persistentVolumeClaim:
-          claimName: glpi-marketplace
+        - name: etc
+          persistentVolumeClaim:
+            claimName: glpi-etc
+        - name: files
+          persistentVolumeClaim:
+            claimName: glpi-files
+        - name: marketplace
+          persistentVolumeClaim:
+            claimName: glpi-marketplace
       restartPolicy: OnFailure
   parallelism: 1
   completions: 1
-status: {}
 {{- end }}
 
 
@@ -139,6 +162,7 @@ metadata:
   namespace: {{ include "glpi.namespace" . }}
   labels:
     {{- include "glpi.labels" . | nindent 4 }}
+    app.kubernetes.io/component: job
   annotations:
     "helm.sh/hook": post-upgrade
     "helm.sh/hook-weight": "10"
@@ -146,58 +170,75 @@ metadata:
 spec:
   template:
     spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "glpi.serviceAccountName" . }}
       {{- with .Values.glpi.podSecurityContext }}
       securityContext:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       initContainers:
-      - name: wait-for-mariadb
-        image: busybox:1.36.1
-        command:
-        - sh
-        - -c
-        - until nc -z $MARIADB_HOST $MARIADB_PORT; do sleep 2; done
-        envFrom:
-        - configMapRef:
-            name: mariadb-glpi-config
+        - name: wait-for-mariadb
+          image: busybox:1.36.1
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 65534
+            capabilities:
+              drop:
+                - ALL
+          command:
+            - sh
+            - -c
+            - until nc -z $MARIADB_HOST $MARIADB_PORT; do sleep 2; done
+          envFrom:
+            - configMapRef:
+                name: mariadb-glpi-config
+          resources:
+            limits:
+              cpu: 100m
+              memory: 64Mi
+            requests:
+              cpu: 50m
+              memory: 32Mi
       containers:
-      - image: {{ include "glpi.phpfpm.image" . }}
-        imagePullPolicy: {{ .Values.glpi.phpfpm.image.pullPolicy }}
-        name: base
-        {{- with .Values.glpi.securityContext }}
-        securityContext:
-          {{- toYaml . | nindent 10 }}
-        {{- end }}
-        command:
-        - sh
-        - -c
-        - "/usr/local/bin/glpi-db-upgrade.sh"
-        envFrom:
-        - configMapRef:
-            name: glpi-config
-        - secretRef:
-            name: glpi-secret
-        volumeMounts:
-        - name: files
-          mountPath: /var/lib/glpi
-        - name: marketplace
-          mountPath: /var/www/html/marketplace
-        - name: etc
-          mountPath: /etc/glpi
+        - image: {{ include "glpi.phpfpm.image" . }}
+          imagePullPolicy: {{ .Values.glpi.phpfpm.image.pullPolicy }}
+          name: base
+          {{- with .Values.glpi.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          command:
+            - sh
+            - -c
+            - "/usr/local/bin/glpi-db-upgrade.sh"
+          envFrom:
+            - configMapRef:
+                name: glpi-config
+            - secretRef:
+                name: glpi-secret
+          volumeMounts:
+            - name: files
+              mountPath: /var/lib/glpi
+            - name: marketplace
+              mountPath: /var/www/html/marketplace
+            - name: etc
+              mountPath: /etc/glpi
       volumes:
-      - name: etc
-        persistentVolumeClaim:
-          claimName: glpi-etc
-      - name: files
-        persistentVolumeClaim:
-          claimName: glpi-files
-      - name: marketplace
-        persistentVolumeClaim:
-          claimName: glpi-marketplace
+        - name: etc
+          persistentVolumeClaim:
+            claimName: glpi-etc
+        - name: files
+          persistentVolumeClaim:
+            claimName: glpi-files
+        - name: marketplace
+          persistentVolumeClaim:
+            claimName: glpi-marketplace
       restartPolicy: OnFailure
   parallelism: 1
   completions: 1
-status: {}
 {{- end }}
 
 
@@ -210,6 +251,7 @@ metadata:
   namespace: {{ include "glpi.namespace" . }}
   labels:
     {{- include "glpi.labels" . | nindent 4 }}
+    app.kubernetes.io/component: job
   annotations:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-weight": "20"
@@ -217,58 +259,75 @@ metadata:
 spec:
   template:
     spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "glpi.serviceAccountName" . }}
       {{- with .Values.glpi.podSecurityContext }}
       securityContext:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       initContainers:
-      - name: wait-for-mariadb
-        image: busybox:1.36.1
-        command:
-        - sh
-        - -c
-        - until nc -z $MARIADB_HOST $MARIADB_PORT; do sleep 2; done
-        envFrom:
-        - configMapRef:
-            name: mariadb-glpi-config
+        - name: wait-for-mariadb
+          image: busybox:1.36.1
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 65534
+            capabilities:
+              drop:
+                - ALL
+          command:
+            - sh
+            - -c
+            - until nc -z $MARIADB_HOST $MARIADB_PORT; do sleep 2; done
+          envFrom:
+            - configMapRef:
+                name: mariadb-glpi-config
+          resources:
+            limits:
+              cpu: 100m
+              memory: 64Mi
+            requests:
+              cpu: 50m
+              memory: 32Mi
       containers:
-      - image: {{ include "glpi.phpfpm.image" . }}
-        imagePullPolicy: {{ .Values.glpi.phpfpm.image.pullPolicy }}
-        name: base
-        {{- with .Values.glpi.securityContext }}
-        securityContext:
-          {{- toYaml . | nindent 10 }}
-        {{- end }}
-        command:
-        - sh
-        - -c
-        - "/usr/local/bin/glpi-db-configure.sh"
-        envFrom:
-        - configMapRef:
-            name: glpi-config
-        - secretRef:
-            name: glpi-secret
-        volumeMounts:
-        - name: etc
-          mountPath: /etc/glpi
-        - name: files
-          mountPath: /var/lib/glpi
-        - name: marketplace
-          mountPath: /var/www/html/marketplace
+        - image: {{ include "glpi.phpfpm.image" . }}
+          imagePullPolicy: {{ .Values.glpi.phpfpm.image.pullPolicy }}
+          name: base
+          {{- with .Values.glpi.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          command:
+            - sh
+            - -c
+            - "/usr/local/bin/glpi-db-configure.sh"
+          envFrom:
+            - configMapRef:
+                name: glpi-config
+            - secretRef:
+                name: glpi-secret
+          volumeMounts:
+            - name: etc
+              mountPath: /etc/glpi
+            - name: files
+              mountPath: /var/lib/glpi
+            - name: marketplace
+              mountPath: /var/www/html/marketplace
       volumes:
-      - name: etc
-        persistentVolumeClaim:
-          claimName: glpi-etc
-      - name: files
-        persistentVolumeClaim:
-          claimName: glpi-files
-      - name: marketplace
-        persistentVolumeClaim:
-          claimName: glpi-marketplace
+        - name: etc
+          persistentVolumeClaim:
+            claimName: glpi-etc
+        - name: files
+          persistentVolumeClaim:
+            claimName: glpi-files
+        - name: marketplace
+          persistentVolumeClaim:
+            claimName: glpi-marketplace
       restartPolicy: OnFailure
   parallelism: 1
   completions: 1
-status: {}
 {{- end }}
 
 
@@ -281,6 +340,7 @@ metadata:
   namespace: {{ include "glpi.namespace" . }}
   labels:
     {{- include "glpi.labels" . | nindent 4 }}
+    app.kubernetes.io/component: job
   annotations:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-weight": "30"
@@ -288,46 +348,50 @@ metadata:
 spec:
   template:
     spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "glpi.serviceAccountName" . }}
       {{- with .Values.glpi.podSecurityContext }}
       securityContext:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       containers:
-      - image: {{ include "glpi.phpfpm.image" . }}
-        imagePullPolicy: {{ .Values.glpi.phpfpm.image.pullPolicy }}
-        name: base
-        {{- with .Values.glpi.securityContext }}
-        securityContext:
-          {{- toYaml . | nindent 10 }}
-        {{- end }}
-        command:
-        - sh
-        - -c
-        - "/usr/local/bin/glpi-cache-configure.sh"
-        envFrom:
-        - configMapRef:
-            name: glpi-config
-        - secretRef:
-            name: glpi-secret
-        volumeMounts:
-        - name: etc
-          mountPath: /etc/glpi
-        - name: files
-          mountPath: /var/lib/glpi
-        - name: marketplace
-          mountPath: /var/www/html/marketplace
+        - image: {{ include "glpi.phpfpm.image" . }}
+          imagePullPolicy: {{ .Values.glpi.phpfpm.image.pullPolicy }}
+          name: base
+          {{- with .Values.glpi.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          command:
+            - sh
+            - -c
+            - "/usr/local/bin/glpi-cache-configure.sh"
+          envFrom:
+            - configMapRef:
+                name: glpi-config
+            - secretRef:
+                name: glpi-secret
+          volumeMounts:
+            - name: etc
+              mountPath: /etc/glpi
+            - name: files
+              mountPath: /var/lib/glpi
+            - name: marketplace
+              mountPath: /var/www/html/marketplace
       volumes:
-      - name: etc
-        persistentVolumeClaim:
-          claimName: glpi-etc
-      - name: files
-        persistentVolumeClaim:
-          claimName: glpi-files
-      - name: marketplace
-        persistentVolumeClaim:
-          claimName: glpi-marketplace
+        - name: etc
+          persistentVolumeClaim:
+            claimName: glpi-etc
+        - name: files
+          persistentVolumeClaim:
+            claimName: glpi-files
+        - name: marketplace
+          persistentVolumeClaim:
+            claimName: glpi-marketplace
       restartPolicy: OnFailure
   parallelism: 1
   completions: 1
-status: {}
 {{- end }}

--- a/kubernetes/glpi/templates/glpi-secret.yaml
+++ b/kubernetes/glpi/templates/glpi-secret.yaml
@@ -7,7 +7,12 @@ metadata:
     {{- include "glpi.labels" . | nindent 4 }}
 type: Opaque
 data:
+  {{- if .Values.mariadb.enabled }}
   MARIADB_DATABASE: {{ .Values.mariadb.auth.database | b64enc | quote }}
   MARIADB_USER: {{ .Values.mariadb.auth.username | b64enc | quote }}
   MARIADB_PASSWORD: {{ .Values.mariadb.auth.password | b64enc | quote }}
-  
+  {{- else if .Values.externalDatabase }}
+  MARIADB_DATABASE: {{ .Values.externalDatabase.database | b64enc | quote }}
+  MARIADB_USER: {{ .Values.externalDatabase.username | b64enc | quote }}
+  MARIADB_PASSWORD: {{ .Values.externalDatabase.password | b64enc | quote }}
+  {{- end }}

--- a/kubernetes/glpi/templates/mariadb-configmap.yaml
+++ b/kubernetes/glpi/templates/mariadb-configmap.yaml
@@ -1,12 +1,12 @@
 {{- if .Values.mariadb.enabled }}
 apiVersion: v1
 kind: ConfigMap
-metadata: 
+metadata:
   name: mariadb-glpi-config
   namespace: {{ include "glpi.namespace" . }}
   labels:
     {{- include "glpi.labels" . | nindent 4 }}
-data: 
+data:
   MARIADB_HOST: "mariadb-headless.{{ include "glpi.namespace" . }}.svc.cluster.local"
   MARIADB_PORT: {{ .Values.mariadb.service.port | quote }}
 {{- end }}

--- a/kubernetes/glpi/templates/mariadb-job.yaml
+++ b/kubernetes/glpi/templates/mariadb-job.yaml
@@ -6,6 +6,7 @@ metadata:
   namespace: {{ include "glpi.namespace" . }}
   labels:
     {{- include "glpi.labels" . | nindent 4 }}
+    app.kubernetes.io/component: job
   annotations:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-weight": "7"
@@ -13,39 +14,58 @@ metadata:
 spec:
   template:
     spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "glpi.serviceAccountName" . }}
       {{- with .Values.mariadb.podSecurityContext }}
       securityContext:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       initContainers:
-      - name: wait-for-mariadb
-        image: busybox:1.36.1
-        command:
-        - sh
-        - -c
-        - until nc -z $MARIADB_HOST $MARIADB_PORT; do sleep 2; done
-        envFrom:
-        - configMapRef:
-            name: mariadb-glpi-config
+        - name: wait-for-mariadb
+          image: busybox:1.36.1
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 65534
+            capabilities:
+              drop:
+                - ALL
+          command:
+            - sh
+            - -c
+            - until nc -z $MARIADB_HOST $MARIADB_PORT; do sleep 2; done
+          envFrom:
+            - configMapRef:
+                name: mariadb-glpi-config
+          resources:
+            limits:
+              cpu: 100m
+              memory: 64Mi
+            requests:
+              cpu: 50m
+              memory: 32Mi
       containers:
-      - image: {{ include "glpi.mariadb.image" . }}
-        imagePullPolicy: {{ .Values.mariadb.image.pullPolicy }}
-        name: base
-        {{- with .Values.mariadb.securityContext }}
-        securityContext:
-          {{- toYaml . | nindent 10 }}
-        {{- end }}
-        command:
-        - sh
-        - -c
-        - "mariadb --host=${MARIADB_HOST} -u root -p${MARIADB_ROOT_PASSWORD} -e \"GRANT SELECT ON mysql.time_zone_name TO 'glpi'@'%'; FLUSH PRIVILEGES;\""
-        envFrom:
-        - secretRef:
-            name: mariadb-glpi-secret
-        - configMapRef:
-            name: mariadb-glpi-config
+        - image: {{ include "glpi.mariadb.image" . }}
+          imagePullPolicy: {{ .Values.mariadb.image.pullPolicy }}
+          name: base
+          {{- with .Values.mariadb.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          command:
+            - sh
+            - -c
+            - |
+              mariadb --host=${MARIADB_HOST} -u root -p${MARIADB_ROOT_PASSWORD} \
+                -e "GRANT SELECT ON mysql.time_zone_name TO '{{ .Values.mariadb.auth.username }}'@'%'; FLUSH PRIVILEGES;"
+          envFrom:
+            - secretRef:
+                name: mariadb-glpi-secret
+            - configMapRef:
+                name: mariadb-glpi-config
       restartPolicy: OnFailure
   parallelism: 1
   completions: 1
-status: {}
 {{- end }}

--- a/kubernetes/glpi/templates/mariadb-persistentvolumeclaim.yaml
+++ b/kubernetes/glpi/templates/mariadb-persistentvolumeclaim.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.mariadb.enabled .Values.mariadb.persistence.enabled }}
+{{- if .Values.mariadb.enabled }}
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim
@@ -6,7 +6,7 @@ metadata:
   name: mariadb-data
   namespace: {{ include "glpi.namespace" . }}
   labels:
-{{ include "glpi.labels" . | indent 4 }}
+    {{- include "glpi.labels" . | nindent 4 }}
 spec:
   {{- if .Values.mariadb.persistence.storageClass }}
   storageClassName: {{ .Values.mariadb.persistence.storageClass }}

--- a/kubernetes/glpi/templates/mariadb-secret.yaml
+++ b/kubernetes/glpi/templates/mariadb-secret.yaml
@@ -1,17 +1,16 @@
 {{- if .Values.mariadb.enabled }}
---- 
+---
 apiVersion: v1
 kind: Secret
 type: Opaque
-metadata: 
+metadata:
   name: mariadb-glpi-secret
   namespace: {{ include "glpi.namespace" . }}
   labels:
-{{ include "glpi.labels" . | indent 4 }}
-data: 
-  MARIADB_ROOT_PASSWORD: {{ .Values.mariadb.auth.rootPassword | b64enc }}
-  MARIADB_DATABASE: {{ .Values.mariadb.auth.database | b64enc }}
-  MARIADB_USER: {{ .Values.mariadb.auth.username | b64enc }}
-  MARIADB_PASSWORD: {{ .Values.mariadb.auth.password | b64enc }}
+    {{- include "glpi.labels" . | nindent 4 }}
+data:
+  MARIADB_ROOT_PASSWORD: {{ .Values.mariadb.auth.rootPassword | b64enc | quote }}
+  MARIADB_DATABASE: {{ .Values.mariadb.auth.database | b64enc | quote }}
+  MARIADB_USER: {{ .Values.mariadb.auth.username | b64enc | quote }}
+  MARIADB_PASSWORD: {{ .Values.mariadb.auth.password | b64enc | quote }}
 {{- end }}
-

--- a/kubernetes/glpi/templates/mariadb-statefulset.yaml
+++ b/kubernetes/glpi/templates/mariadb-statefulset.yaml
@@ -17,7 +17,6 @@ spec:
       {{- include "glpi.selectorLabels" . | nindent 6 }}
       role: primary
   serviceName: mariadb-headless
-  terminationGracePeriodSeconds: 120
   template:
     metadata:
       labels:
@@ -56,6 +55,7 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      terminationGracePeriodSeconds: 120
       containers:
         - image: {{ include "glpi.mariadb.image" . }}
           name: mariadb

--- a/kubernetes/glpi/templates/mariadb-statefulset.yaml
+++ b/kubernetes/glpi/templates/mariadb-statefulset.yaml
@@ -4,7 +4,7 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   labels:
-{{ include "glpi.labels" . | indent 4 }}
+    {{- include "glpi.labels" . | nindent 4 }}
     app.kubernetes.io/component: primary
   name: mariadb
   namespace: {{ include "glpi.namespace" . }}
@@ -14,63 +14,86 @@ spec:
   revisionHistoryLimit: 10
   selector:
     matchLabels:
-{{ include "glpi.selectorLabels" . | indent 6 }}
+      {{- include "glpi.selectorLabels" . | nindent 6 }}
       role: primary
   serviceName: mariadb-headless
+  terminationGracePeriodSeconds: 120
   template:
     metadata:
       labels:
-{{ include "glpi.labels" . | indent 8 }}
+        {{- include "glpi.selectorLabels" . | nindent 8 }}
         app.kubernetes.io/component: primary
         role: primary
       name: mariadb
     spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- with .Values.mariadb.podSecurityContext }}
       securityContext:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       affinity:
+        {{- if .Values.affinity }}
+        {{- toYaml .Values.affinity | nindent 8 }}
+        {{- else }}
         podAntiAffinity:
-          preferredDuringSchedulingIgnoredDuringExecution:
-          - podAffinityTerm:
-              labelSelector:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
                 matchLabels:
-{{ include "glpi.selectorLabels" . | indent 18 }}
+                  {{- include "glpi.selectorLabels" . | nindent 18 }}
                   app.kubernetes.io/component: primary
               namespaces:
-              - {{ include "glpi.namespace" . }}
+                - {{ include "glpi.namespace" . }}
               topologyKey: kubernetes.io/hostname
-            weight: 1
-      containers:
-      - image: {{ include "glpi.mariadb.image" . }}
-        name: mariadb
-        {{- with .Values.mariadb.securityContext }}
-        securityContext:
-          {{- toYaml . | nindent 10 }}
         {{- end }}
-        imagePullPolicy: {{ .Values.mariadb.image.pullPolicy }}
-        envFrom: 
-        - secretRef: 
-            name: mariadb-glpi-secret
-        ports:
-        - containerPort: 3306
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - image: {{ include "glpi.mariadb.image" . }}
           name: mariadb
-          protocol: TCP
-        resources:
-{{ toYaml .Values.mariadb.primary.resources | indent 10 }}
-        volumeMounts:
-        - name: data
-          mountPath: "/var/lib/mysql"
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
-      volumes: 
-      - name: data
-        persistentVolumeClaim:
-          claimName: mariadb-data
+          {{- with .Values.mariadb.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          imagePullPolicy: {{ .Values.mariadb.image.pullPolicy }}
+          envFrom:
+            - secretRef:
+                name: mariadb-glpi-secret
+          ports:
+            - containerPort: 3306
+              name: mariadb
+              protocol: TCP
+          resources:
+            {{- toYaml .Values.mariadb.primary.resources | nindent 12 }}
+          volumeMounts:
+            - name: data
+              mountPath: "/var/lib/mysql"
+          terminationMessagePath: /dev/termination-log
+          terminationMessagePolicy: File
   updateStrategy:
     type: OnDelete
-status: 
-  replicas: {{ .Values.mariadb.replicaCount }}
+  volumeClaimTemplates:
+    - metadata:
+        name: data
+        labels:
+          {{- include "glpi.labels" . | nindent 10 }}
+      spec:
+        accessModes:
+          - {{ .Values.mariadb.persistence.accessMode }}
+        resources:
+          requests:
+            storage: {{ .Values.mariadb.persistence.size }}
+        {{- if .Values.mariadb.persistence.storageClass }}
+        storageClassName: {{ .Values.mariadb.persistence.storageClass }}
+        {{- end }}
 
 
 ---
@@ -78,30 +101,27 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-{{ include "glpi.labels" . | indent 4 }}
-    service.alpha.kubernetes.io/tolerate-unready-endpoints: "true"
+    {{- include "glpi.labels" . | nindent 4 }}
   name: mariadb-headless
   namespace: {{ include "glpi.namespace" . }}
 spec:
   clusterIP: None
   clusterIPs:
-  - None
+    - None
   ipFamilies:
-  - IPv4
+    - IPv4
   ipFamilyPolicy: SingleStack
   ports:
-  - name: mariadb 
-    port: {{ .Values.mariadb.service.port }}
-    protocol: TCP
-    targetPort: {{ .Values.mariadb.service.port }}
+    - name: mariadb
+      port: {{ .Values.mariadb.service.port }}
+      protocol: TCP
+      targetPort: {{ .Values.mariadb.service.port }}
   publishNotReadyAddresses: true
   selector:
-{{ include "glpi.selectorLabels" . | indent 4 }}
+    {{- include "glpi.selectorLabels" . | nindent 4 }}
     role: primary
   sessionAffinity: None
   type: ClusterIP
-status:
-  loadBalancer: {}
 
 
 ---
@@ -109,27 +129,21 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-{{ include "glpi.labels" . | indent 4 }}
+    {{- include "glpi.labels" . | nindent 4 }}
   name: mariadb
   namespace: {{ include "glpi.namespace" . }}
 spec:
   ipFamilies:
-  - IPv4
+    - IPv4
   ipFamilyPolicy: SingleStack
   ports:
-  - name: mariadb
-    port: {{ .Values.mariadb.service.port }}
-    protocol: TCP
-    targetPort: {{ .Values.mariadb.service.port }}
+    - name: mariadb
+      port: {{ .Values.mariadb.service.port }}
+      protocol: TCP
+      targetPort: {{ .Values.mariadb.service.port }}
   selector:
-{{ include "glpi.selectorLabels" . | indent 4 }}
+    {{- include "glpi.selectorLabels" . | nindent 4 }}
     role: primary
   sessionAffinity: None
   type: {{ .Values.mariadb.service.type }}
-status:
-  loadBalancer: {}
 {{- end }}
-
-
-
-

--- a/kubernetes/glpi/templates/redis-deployment.yaml
+++ b/kubernetes/glpi/templates/redis-deployment.yaml
@@ -6,32 +6,71 @@ metadata:
   namespace: {{ include "glpi.namespace" . }}
   labels:
     {{- include "glpi.labels" . | nindent 4 }}
+    app.kubernetes.io/component: redis
 spec:
   replicas: {{ .Values.redis.replicaCount }}
   selector:
     matchLabels:
       {{- include "glpi.selectorLabels" . | nindent 6 }}
-      app: redis
+      app.kubernetes.io/component: redis
   template:
     metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       labels:
         {{- include "glpi.selectorLabels" . | nindent 8 }}
-        app: redis
+        app.kubernetes.io/component: redis
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
     spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "glpi.serviceAccountName" . }}
       {{- with .Values.redis.podSecurityContext }}
       securityContext:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
-      - name: redis
-        {{- with .Values.redis.securityContext }}
-        securityContext:
-          {{- toYaml . | nindent 10 }}
-        {{- end }}
-        image: {{ include "glpi.redis.image" . }}
-        imagePullPolicy: {{ .Values.redis.image.pullPolicy }}
-        ports:
-        - containerPort: 6379
-        resources:
-          {{- toYaml .Values.redis.resources | nindent 10 }}
+        - name: redis
+          {{- with .Values.redis.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          image: {{ include "glpi.redis.image" . }}
+          imagePullPolicy: {{ .Values.redis.image.pullPolicy }}
+          ports:
+            - containerPort: 6379
+          livenessProbe:
+            tcpSocket:
+              port: 6379
+            initialDelaySeconds: 15
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
+          readinessProbe:
+            tcpSocket:
+              port: 6379
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            timeoutSeconds: 3
+            failureThreshold: 3
+          resources:
+            {{- toYaml .Values.redis.resources | nindent 12 }}
 {{- end }}

--- a/kubernetes/glpi/templates/redis-service.yaml
+++ b/kubernetes/glpi/templates/redis-service.yaml
@@ -6,13 +6,14 @@ metadata:
   namespace: {{ include "glpi.namespace" . }}
   labels:
     {{- include "glpi.labels" . | nindent 4 }}
+    app.kubernetes.io/component: redis
 spec:
   type: {{ .Values.redis.service.type }}
   selector:
     {{- include "glpi.selectorLabels" . | nindent 4 }}
-    app: redis
+    app.kubernetes.io/component: redis
   ports:
     - protocol: TCP
       port: {{ .Values.redis.service.port }}
-      targetPort: 6379
+      targetPort: {{ .Values.redis.service.targetPort }}
 {{- end }}

--- a/kubernetes/glpi/templates/serviceaccount.yaml
+++ b/kubernetes/glpi/templates/serviceaccount.yaml
@@ -1,0 +1,14 @@
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "glpi.serviceAccountName" . }}
+  namespace: {{ include "glpi.namespace" . }}
+  labels:
+    {{- include "glpi.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automount }}
+{{- end }}

--- a/kubernetes/glpi/values.yaml
+++ b/kubernetes/glpi/values.yaml
@@ -279,11 +279,17 @@ mariadb:
 
   # -- MariaDB Pod Security Context
   # Security settings applied at the pod level
-  podSecurityContext: {}
+  podSecurityContext:
+    fsGroup: 1001
 
   # -- MariaDB Container Security Context
   # Security settings applied at the container level
-  securityContext: {}
+  securityContext:
+    runAsNonRoot: true
+    runAsUser: 1001
+    capabilities:
+      drop:
+        - ALL
 
 # -- Redis Cache Configuration
 redis:
@@ -318,14 +324,22 @@ redis:
     type: ClusterIP
     # Service port for Redis connections
     port: 6379
+    # Target port on the container
+    targetPort: 6379
 
   # -- Redis Pod Security Context
   # Security settings applied at the pod level
-  podSecurityContext: {}
+  podSecurityContext:
+    fsGroup: 1001
 
   # -- Redis Container Security Context
   # Security settings applied at the container level
-  securityContext: {}
+  securityContext:
+    runAsNonRoot: true
+    runAsUser: 999
+    capabilities:
+      drop:
+        - ALL
 
 # -- Ingress Configuration
 # Configure ingress to expose GLPI externally
@@ -414,3 +428,15 @@ tolerations: []
 #           values:
 #           - node1
 affinity: {}
+
+# -- External Database Configuration
+# Used when mariadb.enabled is false
+externalDatabase:
+  # External database hostname or IP
+  host: ""
+  # External database name
+  database: ""
+  # External database username
+  username: ""
+  # External database password
+  password: ""


### PR DESCRIPTION
## Summary

Major Helm chart fixes (v11.0.7-1), CI fix, and documentation updates.

### Chart Fixes (18 files, 803 insertions, 489 deletions)

**Critical:**
- Fix CronJob YAML indentation preventing deployment
- Fix Ingress backend service name to match nginx service
- StatefulSet: volumeClaimTemplates for multi-replica, requiredDuringScheduling anti-affinity
- Fix terminationGracePeriodSeconds placement

**High:**
- Add app.kubernetes.io/component labels consistently across templates
- Add ServiceAccount template, imagePullSecrets, scheduling values
- Add external database support via `externalDatabase` config
- Add security contexts + resource limits to init containers
- Redis: add liveness/readiness probes and non-root security context
- MariaDB/Redis: non-root security contexts by default
- Fix GLPI_DOC_DIR pointing to /var/www/html
- Remove deprecated annotations and status subresource fields

### CI Fix
- `helm-publish.yaml`: publish job condition fixed for release events

### Documentation
- AGENTS.md, README.md, docker/.env.example, kubernetes/glpi/README.md

### Published
- gh-pages index.yaml: `11.0.7-1` entry
- Release `glpi-11.0.7-1` on GitHub