### PR TITLE
chore: bump version from 11.0.7 to 11.0.8

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,8 +20,8 @@ docker-compose -f docker-compose-build.yml build
 
 # Build specific image
 docker build -t eftechcombr/glpi:base -f docker/php/Dockerfile.base docker/php/
-docker build -t eftechcombr/glpi:php-fpm-11.0.7 -f docker/php/Dockerfile docker/php/
-docker build -t eftechcombr/glpi:nginx-11.0.7 -f docker/nginx/Dockerfile docker/nginx/
+docker build -t eftechcombr/glpi:php-fpm-11.0.8 -f docker/php/Dockerfile docker/php/
+docker build -t eftechcombr/glpi:nginx-11.0.8 -f docker/nginx/Dockerfile docker/nginx/
 ```
 
 ### Run Containers
@@ -95,7 +95,7 @@ docker-php-ext-enable redis
 ### Docker Compose
 
 #### Version Tagging
-- Always use explicit version tags (e.g., `11.0.7`, not `latest`)
+- Always use explicit version tags (e.g., `11.0.8`, not `latest`)
 - Keep all service image tags synchronized
 - Use semantic versioning
 
@@ -165,7 +165,7 @@ trap 'echo "Error on line $LINENO"' ERR
 ### Images
 - Lowercase: `eftechcombr/glpi`
 - Use kebab-case: `php-fpm`, `nginx`
-- Version format: `11.0.7`
+- Version format: `11.0.8`
 
 ### Services (docker-compose)
 - Lowercase with hyphens: `mariadb`, `glpi-db-install`

--- a/README.md
+++ b/README.md
@@ -9,9 +9,9 @@ Manifest files for building and deploying **GLPI** using containers with Docker 
 
 - [x] PHP-FPM: `php:8.4.19-fpm-alpine3.22`
 - [x] Nginx: `nginxinc/nginx-unprivileged:1.27.5-alpine3.21-slim`
-- [x] GLPI PHP: `eftechcombr/glpi:php-fpm-11.0.7`
-- [x] GLPI Nginx: `eftechcombr/glpi:nginx-11.0.7`
+- [x] GLPI PHP: `eftechcombr/glpi:php-fpm-11.0.8`
 
+  - [x] GLPI Nginx: `eftechcombr/glpi:nginx-11.0.8`
 ## Quick Start
 
 ### Using Helm (Kubernetes)

--- a/docker/.env.example
+++ b/docker/.env.example
@@ -1,5 +1,5 @@
 GLPI_LANG="en_US"
-VERSION="11.0.7"
+VERSION="11.0.8"
 GLPI_MARKETPLACE_DIR=/var/www/html/marketplace
 GLPI_VAR_DIR=/var/lib/glpi
 GLPI_DOC_DIR=/var/lib/glpi

--- a/docker/docker-compose-build.yml
+++ b/docker/docker-compose-build.yml
@@ -23,7 +23,7 @@ services:
 
 
   glpi-db-upgrade:
-    image: eftechcombr/glpi:php-fpm-11.0.7
+    image: eftechcombr/glpi:php-fpm-11.0.8
     restart: on-failure 
     env_file: ./.env
     volumes: 
@@ -37,7 +37,7 @@ services:
 
 
   glpi-db-install:
-    image: eftechcombr/glpi:php-fpm-11.0.7
+    image: eftechcombr/glpi:php-fpm-11.0.8
     restart: on-failure 
     env_file: ./.env
     volumes: 
@@ -50,7 +50,7 @@ services:
       - /usr/local/bin/glpi-db-install.sh
 
   glpi-verify-dir: 
-    image: eftechcombr/glpi:php-fpm-11.0.7
+    image: eftechcombr/glpi:php-fpm-11.0.8
     restart: on-failure
     volumes: 
       - glpi-marketplace:/var/www/html/marketplace:rw
@@ -63,7 +63,7 @@ services:
       - /usr/local/bin/glpi-verify-dir.sh
 
   glpi-db-configure: 
-    image: eftechcombr/glpi:php-fpm-11.0.7
+    image: eftechcombr/glpi:php-fpm-11.0.8
     restart: on-failure
     volumes: 
       - glpi-marketplace:/var/www/html/marketplace:rw
@@ -76,7 +76,7 @@ services:
       - /usr/local/bin/glpi-db-configure.sh
 
   glpi-cache-configure: 
-    image: eftechcombr/glpi:php-fpm-11.0.7
+    image: eftechcombr/glpi:php-fpm-11.0.8
     restart: on-failure
     volumes: 
       - glpi-marketplace:/var/www/html/marketplace:rw
@@ -99,7 +99,7 @@ services:
 
   php: 
     build: php/
-    image: eftechcombr/glpi:php-fpm-11.0.7
+    image: eftechcombr/glpi:php-fpm-11.0.8
     restart: unless-stopped
     volumes: 
       - glpi-marketplace:/var/www/html/marketplace:rw
@@ -116,7 +116,7 @@ services:
 
   nginx: 
     build: nginx/
-    image: eftechcombr/glpi:nginx-11.0.7
+    image: eftechcombr/glpi:nginx-11.0.8
     restart: unless-stopped
     ports: 
       - "8080:8080"

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -22,7 +22,7 @@ services:
     command: mariadb -h $MARIADB_HOST -u root -p$MARIADB_ROOT_PASSWORD -e "GRANT SELECT ON \`mysql\`.\`time_zone_name\` TO 'glpi'@'%'; FLUSH PRIVILEGES;"
 
   glpi-db-install:
-    image: eftechcombr/glpi:php-fpm-11.0.7
+    image: eftechcombr/glpi:php-fpm-11.0.8
     restart: on-failure 
     env_file: ./.env
     volumes: 
@@ -35,7 +35,7 @@ services:
       - /usr/local/bin/glpi-db-install.sh
 
   glpi-verify-dir: 
-    image: eftechcombr/glpi:php-fpm-11.0.7
+    image: eftechcombr/glpi:php-fpm-11.0.8
     restart: on-failure
     volumes: 
       - glpi-marketplace:/var/www/html/marketplace:rw
@@ -48,7 +48,7 @@ services:
       - /usr/local/bin/glpi-verify-dir.sh
 
   glpi-db-configure: 
-    image: eftechcombr/glpi:php-fpm-11.0.7
+    image: eftechcombr/glpi:php-fpm-11.0.8
     restart: on-failure
     volumes: 
       - glpi-marketplace:/var/www/html/marketplace:rw
@@ -60,7 +60,7 @@ services:
     command: 
       - /usr/local/bin/glpi-db-configure.sh
   glpi-cache-configure: 
-    image: eftechcombr/glpi:php-fpm-11.0.7
+    image: eftechcombr/glpi:php-fpm-11.0.8
     restart: on-failure
     volumes: 
       - glpi-marketplace:/var/www/html/marketplace:rw
@@ -73,7 +73,7 @@ services:
       - /usr/local/bin/glpi-cache-configure.sh
 
   php: 
-    image: eftechcombr/glpi:php-fpm-11.0.7
+    image: eftechcombr/glpi:php-fpm-11.0.8
     restart: unless-stopped
     volumes: 
       - glpi-marketplace:/var/www/html/marketplace:rw
@@ -89,7 +89,7 @@ services:
       - "9000:9000"
 
   nginx: 
-    image: eftechcombr/glpi:nginx-11.0.7
+    image: eftechcombr/glpi:nginx-11.0.8
     restart: unless-stopped
     ports: 
       - "8080:8080"

--- a/docker/nginx/Dockerfile
+++ b/docker/nginx/Dockerfile
@@ -1,4 +1,4 @@
-FROM eftechcombr/glpi:php-fpm-11.0.7 as BUILD
+FROM eftechcombr/glpi:php-fpm-11.0.8 as BUILD
 #
 
 FROM nginxinc/nginx-unprivileged:1.27.5-alpine3.21-slim

--- a/docker/php/Dockerfile
+++ b/docker/php/Dockerfile
@@ -1,6 +1,6 @@
 FROM eftechcombr/glpi:base 
 
-ENV VERSION=11.0.7 
+ENV VERSION=11.0.8 
 ENV GLPI_LANG=en_US 
 ENV CACHE_DSN=redis://redis:6379/
 ENV MARIADB_HOST=mariadb-glpi 

--- a/kubernetes/glpi/Chart.yaml
+++ b/kubernetes/glpi/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: glpi
 description: GLPI Helm Chart - IT Asset Management and Service Desk
 type: application
-version: 11.0.7
-appVersion: "11.0.7"
+version: 11.0.8
+appVersion: "11.0.8"
 
 # Artifact Hub Metadata
 home: https://github.com/eftechcombr/glpi

--- a/kubernetes/glpi/README.md
+++ b/kubernetes/glpi/README.md
@@ -31,7 +31,7 @@ The following table lists the configurable parameters of the GLPI chart and thei
 
 | Parameter | Description | Default |
 |-----------|-------------|---------|
-| `glpi.version` | GLPI version to deploy | `"11.0.7"` |
+| `glpi.version` | GLPI version to deploy | `"11.0.8"` |
 | `glpi.language` | Default language for GLPI | `en_US` |
 
 ### PHP-FPM Configuration
@@ -39,7 +39,7 @@ The following table lists the configurable parameters of the GLPI chart and thei
 | Parameter | Description | Default |
 |-----------|-------------|---------|
 | `glpi.phpfpm.image.repository` | PHP-FPM image repository | `eftechcombr/glpi` |
-| `glpi.phpfpm.image.tag` | PHP-FPM image tag | `php-fpm-11.0.7` |
+| `glpi.phpfpm.image.tag` | PHP-FPM image tag | `php-fpm-11.0.8` |
 | `glpi.phpfpm.image.pullPolicy` | PHP-FPM image pull policy | `IfNotPresent` |
 | `glpi.phpfpm.replicaCount` | Number of PHP-FPM pods | `1` |
 | `glpi.phpfpm.resources.limits.cpu` | PHP-FPM container CPU limit | `1000m` |
@@ -54,7 +54,7 @@ The following table lists the configurable parameters of the GLPI chart and thei
 | Parameter | Description | Default |
 |-----------|-------------|---------|
 | `glpi.nginx.image.repository` | Nginx image repository | `eftechcombr/glpi` |
-| `glpi.nginx.image.tag` | Nginx image tag | `nginx-11.0.7` |
+| `glpi.nginx.image.tag` | Nginx image tag | `nginx-11.0.8` |
 | `glpi.nginx.image.pullPolicy` | Nginx image pull policy | `IfNotPresent` |
 | `glpi.nginx.replicaCount` | Number of Nginx pods | `1` |
 | `glpi.nginx.resources.limits.cpu` | Nginx container CPU limit | `500m` |

--- a/kubernetes/glpi/values.yaml
+++ b/kubernetes/glpi/values.yaml
@@ -16,7 +16,7 @@ global:
 # -- GLPI Application Configuration
 glpi:
   # GLPI version to deploy
-  version: "11.0.7"
+  version: "11.0.8"
   
   # GLPI default language (e.g., en_US, fr_FR, pt_BR)
   language: "en_US"
@@ -28,7 +28,7 @@ glpi:
       # Image repository for PHP-FPM
       repository: eftechcombr/glpi
       # Image tag for PHP-FPM
-      tag: php-fpm-11.0.7
+      tag: php-fpm-11.0.8
       # Image pull policy
       pullPolicy: IfNotPresent
     
@@ -75,7 +75,7 @@ glpi:
       # Image repository for Nginx
       repository: eftechcombr/glpi
       # Image tag for Nginx
-      tag: nginx-11.0.7
+      tag: nginx-11.0.8
       # Image pull policy
       pullPolicy: IfNotPresent
     


### PR DESCRIPTION
Update all version references from 11.0.7 to 11.0.8 across Dockerfiles, docker-compose configs, Helm chart, and documentation.