### PR TITLE
fix(helm): fix mariadb.enabled=false causing configmap and job failures

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 
 .env
 */.env
+values-custom.yaml
+*/values-custom.yaml

--- a/kubernetes/glpi/templates/glpi-configmap.yaml
+++ b/kubernetes/glpi/templates/glpi-configmap.yaml
@@ -27,10 +27,11 @@ data:
 
   {{- if .Values.mariadb.enabled }}
   MARIADB_HOST: "mariadb-headless.{{ include "glpi.namespace" . }}.svc.cluster.local"
-  {{- else if .Values.externalDatabase }}
-  MARIADB_HOST: {{ .Values.externalDatabase.host | quote }}
-  {{- end }}
   MARIADB_PORT: {{ .Values.mariadb.service.port | quote }}
+  {{- else }}
+  MARIADB_HOST: {{ .Values.externalDatabase.host | quote }}
+  MARIADB_PORT: {{ .Values.externalDatabase.port | quote }}
+  {{- end }}
 
 
 ---

--- a/kubernetes/glpi/templates/glpi-job.yaml
+++ b/kubernetes/glpi/templates/glpi-job.yaml
@@ -105,7 +105,7 @@ spec:
             - until nc -z $MARIADB_HOST $MARIADB_PORT; do sleep 2; done
           envFrom:
             - configMapRef:
-                name: mariadb-glpi-config
+                name: glpi-config
           resources:
             limits:
               cpu: 100m
@@ -194,7 +194,7 @@ spec:
             - until nc -z $MARIADB_HOST $MARIADB_PORT; do sleep 2; done
           envFrom:
             - configMapRef:
-                name: mariadb-glpi-config
+                name: glpi-config
           resources:
             limits:
               cpu: 100m
@@ -283,7 +283,7 @@ spec:
             - until nc -z $MARIADB_HOST $MARIADB_PORT; do sleep 2; done
           envFrom:
             - configMapRef:
-                name: mariadb-glpi-config
+                name: glpi-config
           resources:
             limits:
               cpu: 100m

--- a/kubernetes/glpi/templates/mariadb-configmap.yaml
+++ b/kubernetes/glpi/templates/mariadb-configmap.yaml
@@ -1,4 +1,3 @@
-{{- if .Values.mariadb.enabled }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -7,6 +6,10 @@ metadata:
   labels:
     {{- include "glpi.labels" . | nindent 4 }}
 data:
+  {{- if .Values.mariadb.enabled }}
   MARIADB_HOST: "mariadb-headless.{{ include "glpi.namespace" . }}.svc.cluster.local"
   MARIADB_PORT: {{ .Values.mariadb.service.port | quote }}
-{{- end }}
+  {{- else }}
+  MARIADB_HOST: {{ .Values.externalDatabase.host | quote }}
+  MARIADB_PORT: {{ .Values.externalDatabase.port | quote }}
+  {{- end }}

--- a/kubernetes/glpi/templates/mariadb-configmap.yaml
+++ b/kubernetes/glpi/templates/mariadb-configmap.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.mariadb.enabled }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -6,10 +7,6 @@ metadata:
   labels:
     {{- include "glpi.labels" . | nindent 4 }}
 data:
-  {{- if .Values.mariadb.enabled }}
   MARIADB_HOST: "mariadb-headless.{{ include "glpi.namespace" . }}.svc.cluster.local"
   MARIADB_PORT: {{ .Values.mariadb.service.port | quote }}
-  {{- else }}
-  MARIADB_HOST: {{ .Values.externalDatabase.host | quote }}
-  MARIADB_PORT: {{ .Values.externalDatabase.port | quote }}
-  {{- end }}
+{{- end }}

--- a/kubernetes/glpi/values.yaml
+++ b/kubernetes/glpi/values.yaml
@@ -434,6 +434,8 @@ affinity: {}
 externalDatabase:
   # External database hostname or IP
   host: ""
+  # External database port
+  port: 3306
   # External database name
   database: ""
   # External database username


### PR DESCRIPTION
## Problem

When `mariadb.enabled: false` is set to use an external database, two bugs caused failures:

1. **Job initContainers failing**: The `wait-for-db` initContainers in `glpi-job.yaml` referenced
   `mariadb-glpi-config`, which is only created when `mariadb.enabled: true`. With an external
   database this ConfigMap does not exist, causing all jobs to crash on startup.

2. **Wrong port reference**: `MARIADB_PORT` in `glpi-configmap.yaml` was outside the `if/else`
   block, always reading from `mariadb.service.port` even when using an external database.

## Fix

- `glpi-job.yaml`: initContainers now reference `glpi-config` instead of `mariadb-glpi-config`.
  `glpi-config` always exists and already contains the correct `MARIADB_HOST` and `MARIADB_PORT`
  for both internal MariaDB and external database scenarios.
- `mariadb-configmap.yaml`: kept scoped to `mariadb.enabled: true` only (internal MariaDB).
- `glpi-configmap.yaml`: `MARIADB_HOST` and `MARIADB_PORT` are now both inside the `if/else`
  block, correctly resolving to the external database values when MariaDB is disabled.
- `values.yaml`: added `externalDatabase.port` field (default: `3306`).

## Testing

Validated with `helm template` using both `mariadb.enabled: true` (default values) and
`mariadb.enabled: false` with `externalDatabase` configured.