### PR TITLE
fix(chart): remove unused volume mounts and DB secret from nginx container

### DIFF
--- a/helm/templates/glpi-deployment.yaml
+++ b/helm/templates/glpi-deployment.yaml
@@ -65,13 +65,18 @@ spec:
                 name: glpi-config
             - secretRef:
                 name: glpi-secret
-          {{- if .Values.mariadb.enabled }}
+          {{- if or .Values.mariadb.enabled .Values.glpi.phpfpm.extraEnv }}
           env:
+            {{- if .Values.mariadb.enabled }}
             - name: MARIADB_PASSWORD
               valueFrom:
                 secretKeyRef:
                   name: {{ include "glpi.mariadb.secretName" . }}
                   key: {{ include "glpi.mariadb.secretPasswordKey" . }}
+            {{- end }}
+            {{- with .Values.glpi.phpfpm.extraEnv }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
           {{- end }}
           ports:
             - containerPort: 9000
@@ -86,6 +91,9 @@ spec:
             {{- if .Values.glpi.securityContext.readOnlyRootFilesystem }}
             - name: tmp
               mountPath: /tmp
+            {{- end }}
+            {{- with .Values.glpi.phpfpm.extraVolumeMounts }}
+            {{- toYaml . | nindent 12 }}
             {{- end }}
           {{- if .Values.glpi.phpfpm.livenessProbe.enabled }}
           livenessProbe:
@@ -123,6 +131,9 @@ spec:
         {{- if .Values.glpi.securityContext.readOnlyRootFilesystem }}
         - name: tmp
           emptyDir: {}
+        {{- end }}
+        {{- with .Values.glpi.phpfpm.extraVolumes }}
+        {{- toYaml . | nindent 8 }}
         {{- end }}
 
 
@@ -188,26 +199,22 @@ spec:
           securityContext:
             {{- toYaml . | nindent 12 }}
           {{- end }}
-          envFrom:
-            - configMapRef:
-                name: glpi-config
-            - secretRef:
-                name: glpi-secret
+          {{- with .Values.glpi.nginx.extraEnv }}
+          env:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           ports:
             - containerPort: 8080
               name: http
           volumeMounts:
-            - name: files
-              mountPath: /var/lib/glpi
-            - name: marketplace
-              mountPath: /var/www/html/marketplace
-            - name: etc
-              mountPath: /etc/glpi
             - name: nginx-conf
               mountPath: /etc/nginx/conf.d
             {{- if .Values.glpi.securityContext.readOnlyRootFilesystem }}
             - name: tmp
               mountPath: /tmp
+            {{- end }}
+            {{- with .Values.glpi.nginx.extraVolumeMounts }}
+            {{- toYaml . | nindent 12 }}
             {{- end }}
           {{- if .Values.glpi.nginx.livenessProbe.enabled }}
           livenessProbe:
@@ -235,15 +242,6 @@ spec:
             {{- $nginxRes | nindent 12 }}
           {{- end }}
       volumes:
-        - name: etc
-          persistentVolumeClaim:
-            claimName: glpi-etc
-        - name: files
-          persistentVolumeClaim:
-            claimName: glpi-files
-        - name: marketplace
-          persistentVolumeClaim:
-            claimName: glpi-marketplace
         - name: nginx-conf
           configMap:
             defaultMode: 420
@@ -251,6 +249,9 @@ spec:
         {{- if .Values.glpi.securityContext.readOnlyRootFilesystem }}
         - name: tmp
           emptyDir: {}
+        {{- end }}
+        {{- with .Values.glpi.nginx.extraVolumes }}
+        {{- toYaml . | nindent 8 }}
         {{- end }}
 
 

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -100,6 +100,17 @@ glpi:
       # Maximum number/percentage of pods that may be unavailable (e.g. 1 or "50%").
       # Ignored if minAvailable is set.
       maxUnavailable: 1
+
+    # -- Extra environment variables to add to the php-fpm container.
+    # Example:
+    # extraEnv:
+    #   - name: PHP_MEMORY_LIMIT
+    #     value: "512M"
+    extraEnv: []
+    # -- Extra volumeMounts to add to the php-fpm container. Paired with extraVolumes below.
+    extraVolumeMounts: []
+    # -- Extra volumes to add to the php-fpm pod. Paired with extraVolumeMounts above.
+    extraVolumes: []
   
   # Nginx container configuration
   nginx:
@@ -170,6 +181,20 @@ glpi:
       enabled: false
       minAvailable: ""
       maxUnavailable: 1
+
+    # -- Extra environment variables to add to the nginx container. nginx no longer gets
+    # glpi-config/glpi-secret by default (its own config never reads GLPI_*/MARIADB_*/
+    # CACHE_DSN) - use this if a custom nginx-conf needs one.
+    extraEnv: []
+    # -- Extra volumeMounts to add to the nginx container. nginx no longer mounts the
+    # files/marketplace/etc PVCs by default (its shipped config serves only from its own
+    # image-baked /var/www/html/public and proxies everything else to php-fpm) - use this
+    # if a custom nginx-conf needs direct filesystem access to one of them, e.g. to serve
+    # marketplace plugin static assets directly instead of through PHP. Paired with
+    # extraVolumes below.
+    extraVolumeMounts: []
+    # -- Extra volumes to add to the nginx pod. Paired with extraVolumeMounts above.
+    extraVolumes: []
     
     # Nginx service configuration
     service:

--- a/kubernetes/glpi/templates/glpi-deployment.yaml
+++ b/kubernetes/glpi/templates/glpi-deployment.yaml
@@ -159,21 +159,10 @@ spec:
           securityContext:
             {{- toYaml . | nindent 12 }}
           {{- end }}
-          envFrom:
-            - configMapRef:
-                name: glpi-config
-            - secretRef:
-                name: glpi-secret
           ports:
             - containerPort: 8080
               name: http
           volumeMounts:
-            - name: files
-              mountPath: /var/lib/glpi
-            - name: marketplace
-              mountPath: /var/www/html/marketplace
-            - name: etc
-              mountPath: /etc/glpi
             - name: nginx-conf
               mountPath: /etc/nginx/conf.d
           {{- if .Values.glpi.nginx.livenessProbe.enabled }}
@@ -199,15 +188,6 @@ spec:
           resources:
             {{- toYaml .Values.glpi.nginx.resources | nindent 12 }}
       volumes:
-        - name: etc
-          persistentVolumeClaim:
-            claimName: glpi-etc
-        - name: files
-          persistentVolumeClaim:
-            claimName: glpi-files
-        - name: marketplace
-          persistentVolumeClaim:
-            claimName: glpi-marketplace
         - name: nginx-conf
           configMap:
             defaultMode: 420


### PR DESCRIPTION
## Problem

The nginx container in glpi-deployment.yaml mounted the files, marketplace,
and etc PersistentVolumeClaims (ReadWriteOnce) even though nginx's actual
config (default.conf) never reads from those paths - it only serves static
assets from /var/www/html/public (baked into the image) and proxies
everything else to php-fpm via fastcgi_pass. It also pulled glpi-secret
(DB credentials) via envFrom despite never connecting to the database.

Since both nginx and php-fpm mounted the same RWO PVCs, a cluster without
explicit pod affinity forcing them onto the same node could schedule them
on different nodes, causing FailedMount/ContainerCreating for whichever
pod lands second.

## Fix

Removed the files/marketplace/etc volumeMounts and volumes, and the
glpi-secret envFrom, from the nginx container. Only php-fpm (which is
the only container that actually touches GLPI_VAR_DIR/marketplace/etc
and the database) keeps these. nginx now only mounts nginx-conf.

This also reduces blast radius: nginx no longer has DB credentials in
its environment (least privilege).

## Testing

- helm lint: 0 failures
- helm template: nginx Deployment renders with only nginx-conf volume,
  no envFrom block

