### PR TITLE
fix(chart): make CACHE_DSN conditional on redis.enabled

### DIFF
--- a/kubernetes/glpi/templates/glpi-configmap.yaml
+++ b/kubernetes/glpi/templates/glpi-configmap.yaml
@@ -33,6 +33,14 @@ data:
   MARIADB_PORT: {{ .Values.externalDatabase.port | quote }}
   {{- end }}
 
+  {{- if .Values.glpi.cache.dsn }}
+  CACHE_DSN: {{ .Values.glpi.cache.dsn | quote }}
+  {{- else if .Values.redis.enabled }}
+  CACHE_DSN: "redis://redis.{{ include "glpi.namespace" . }}.svc.cluster.local:{{ .Values.redis.service.port }}/"
+  {{- else }}
+  CACHE_DSN: ""
+  {{- end }}
+
 
 ---
 apiVersion: v1

--- a/kubernetes/glpi/values.yaml
+++ b/kubernetes/glpi/values.yaml
@@ -201,6 +201,15 @@ glpi:
     # Schedule in cron format (default: every 2 minutes)
     schedule: "*/2 * * * *"
 
+  # -- Cache Configuration
+  cache:
+    # Override CACHE_DSN used by the glpi-cache-configure job.
+    # Leave empty to auto-generate from redis.* (redis://redis.<namespace>.svc.cluster.local:<port>/)
+    # when redis.enabled is true. If redis.enabled is false and this is left empty, caching is
+    # disabled (GLPI falls back to filesystem cache). Set this to point to an external
+    # Redis/Memcached instance instead of the bundled one, e.g. "redis://my-external-redis:6379/2"
+    dsn: ""
+
   # -- GLPI Pod Security Context
   # Security settings applied at the pod level
   podSecurityContext:


### PR DESCRIPTION
## Problem

The php-fpm image bakes ENV CACHE_DSN=redis://redis:6379/ directly into
the Dockerfile. The chart's glpi-config ConfigMap never set CACHE_DSN at
all, so it silently relied on that image default. This worked by
coincidence when redis.enabled=true (the Redis Service happens to be
named 'redis'), but when a user sets redis.enabled=false, no Redis
Service/Deployment is created while the image-baked CACHE_DSN still
points at it. The glpi-cache-configure post-install/post-upgrade hook Job
then runs 'cache:configure --dsn=redis://redis:6379/' against a
nonexistent service, fails, and blocks the release (Helm won't proceed
past a failed hook).

Same root cause pattern as #166 (MARIADB_HOST/PORT not properly scoped
to the mariadb.enabled toggle).

## Fix

- glpi-configmap.yaml now explicitly sets CACHE_DSN:
  - glpi.cache.dsn override if set (points to any external cache)
  - else auto-generated redis://redis.<namespace>.svc.cluster.local:<port>/
    when redis.enabled=true
  - else empty string, which glpi-cache-configure.sh already handles
    gracefully ('CACHE_DSN is not set. Skipping cache configuration.')
- Added glpi.cache.dsn to values.yaml for pointing at an external
  Redis/Memcached instance without touching templates.

## Testing

- helm lint: 0 failures
- helm template (default, redis.enabled=true): CACHE_DSN=redis://redis.default.svc.cluster.local:6379/
- helm template --set redis.enabled=false: CACHE_DSN="" (was previously unset/inherited from image)
- helm template --set glpi.cache.dsn=redis://external:6380/2: override respected

