### PR TITLE
feat(chart): support existingSecret for DB credentials (Doppler / External Secrets / Vault compatible)

### DIFF
--- a/kubernetes/glpi/templates/_helpers.tpl
+++ b/kubernetes/glpi/templates/_helpers.tpl
@@ -88,6 +88,38 @@ Return the proper MariaDB image name
 {{- end }}
 
 {{/*
+Return the name of the Secret holding MariaDB server credentials
+(MARIADB_ROOT_PASSWORD, MARIADB_DATABASE, MARIADB_USER, MARIADB_PASSWORD).
+Used by the MariaDB StatefulSet itself and the mariadb-timezone Job.
+Set mariadb.auth.existingSecret to reference a Secret managed outside this
+chart (e.g. synced by Doppler, External Secrets Operator, Vault) instead of
+letting the chart create one from plaintext values.yaml values.
+*/}}
+{{- define "glpi.mariadbSecretName" -}}
+{{- if .Values.mariadb.auth.existingSecret -}}
+{{- .Values.mariadb.auth.existingSecret -}}
+{{- else -}}
+mariadb-glpi-secret
+{{- end -}}
+{{- end }}
+
+{{/*
+Return the name of the Secret holding the GLPI application's DB credentials
+(MARIADB_DATABASE, MARIADB_USER, MARIADB_PASSWORD - no root password).
+Used by php-fpm, all init Jobs, and the cronjob.
+Set glpi.database.existingSecret to reference a Secret managed outside this
+chart instead of letting the chart create one from plaintext values.yaml
+values. Applies regardless of mariadb.enabled (internal or external DB).
+*/}}
+{{- define "glpi.databaseSecretName" -}}
+{{- if .Values.glpi.database.existingSecret -}}
+{{- .Values.glpi.database.existingSecret -}}
+{{- else -}}
+glpi-secret
+{{- end -}}
+{{- end }}
+
+{{/*
 Return the proper Redis image name
 */}}
 {{- define "glpi.redis.image" -}}

--- a/kubernetes/glpi/templates/glpi-cronjob.yaml
+++ b/kubernetes/glpi/templates/glpi-cronjob.yaml
@@ -47,7 +47,7 @@ spec:
                 - configMapRef: 
                     name: glpi-config
                 - secretRef: 
-                    name: glpi-secret
+                    name: {{ include "glpi.databaseSecretName" . }}
               command: 
                 - php
                 - front/cron.php

--- a/kubernetes/glpi/templates/glpi-deployment.yaml
+++ b/kubernetes/glpi/templates/glpi-deployment.yaml
@@ -59,7 +59,7 @@ spec:
             - configMapRef:
                 name: glpi-config
             - secretRef:
-                name: glpi-secret
+                name: {{ include "glpi.databaseSecretName" . }}
           ports:
             - containerPort: 9000
               name: fpm
@@ -163,7 +163,7 @@ spec:
             - configMapRef:
                 name: glpi-config
             - secretRef:
-                name: glpi-secret
+                name: {{ include "glpi.databaseSecretName" . }}
           ports:
             - containerPort: 8080
               name: http

--- a/kubernetes/glpi/templates/glpi-job.yaml
+++ b/kubernetes/glpi/templates/glpi-job.yaml
@@ -36,7 +36,7 @@ spec:
             - configMapRef:
                 name: glpi-config
             - secretRef:
-                name: glpi-secret
+                name: {{ include "glpi.databaseSecretName" . }}
           command:
             - sh
             - -c
@@ -129,7 +129,7 @@ spec:
             - configMapRef:
                 name: glpi-config
             - secretRef:
-                name: glpi-secret
+                name: {{ include "glpi.databaseSecretName" . }}
           volumeMounts:
             - name: files
               mountPath: /var/lib/glpi
@@ -218,7 +218,7 @@ spec:
             - configMapRef:
                 name: glpi-config
             - secretRef:
-                name: glpi-secret
+                name: {{ include "glpi.databaseSecretName" . }}
           volumeMounts:
             - name: files
               mountPath: /var/lib/glpi
@@ -307,7 +307,7 @@ spec:
             - configMapRef:
                 name: glpi-config
             - secretRef:
-                name: glpi-secret
+                name: {{ include "glpi.databaseSecretName" . }}
           volumeMounts:
             - name: etc
               mountPath: /etc/glpi
@@ -373,7 +373,7 @@ spec:
             - configMapRef:
                 name: glpi-config
             - secretRef:
-                name: glpi-secret
+                name: {{ include "glpi.databaseSecretName" . }}
           volumeMounts:
             - name: etc
               mountPath: /etc/glpi

--- a/kubernetes/glpi/templates/glpi-secret.yaml
+++ b/kubernetes/glpi/templates/glpi-secret.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.glpi.database.existingSecret }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -16,3 +17,4 @@ data:
   MARIADB_USER: {{ .Values.externalDatabase.username | b64enc | quote }}
   MARIADB_PASSWORD: {{ .Values.externalDatabase.password | b64enc | quote }}
   {{- end }}
+{{- end }}

--- a/kubernetes/glpi/templates/mariadb-job.yaml
+++ b/kubernetes/glpi/templates/mariadb-job.yaml
@@ -62,7 +62,7 @@ spec:
                 -e "GRANT SELECT ON mysql.time_zone_name TO '{{ .Values.mariadb.auth.username }}'@'%'; FLUSH PRIVILEGES;"
           envFrom:
             - secretRef:
-                name: mariadb-glpi-secret
+                name: {{ include "glpi.mariadbSecretName" . }}
             - configMapRef:
                 name: mariadb-glpi-config
       restartPolicy: OnFailure

--- a/kubernetes/glpi/templates/mariadb-secret.yaml
+++ b/kubernetes/glpi/templates/mariadb-secret.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.mariadb.enabled }}
+{{- if and .Values.mariadb.enabled (not .Values.mariadb.auth.existingSecret) }}
 ---
 apiVersion: v1
 kind: Secret

--- a/kubernetes/glpi/templates/mariadb-statefulset.yaml
+++ b/kubernetes/glpi/templates/mariadb-statefulset.yaml
@@ -66,7 +66,7 @@ spec:
           imagePullPolicy: {{ .Values.mariadb.image.pullPolicy }}
           envFrom:
             - secretRef:
-                name: mariadb-glpi-secret
+                name: {{ include "glpi.mariadbSecretName" . }}
           ports:
             - containerPort: 3306
               name: mariadb

--- a/kubernetes/glpi/values.yaml
+++ b/kubernetes/glpi/values.yaml
@@ -201,6 +201,17 @@ glpi:
     # Schedule in cron format (default: every 2 minutes)
     schedule: "*/2 * * * *"
 
+  # -- Database Credentials Configuration
+  database:
+    # Name of an existing Secret containing the GLPI application's DB credentials,
+    # sourced from an external secrets manager (Doppler, External Secrets Operator,
+    # Vault, etc). Must contain keys: MARIADB_DATABASE, MARIADB_USER, MARIADB_PASSWORD.
+    # When set, this chart will not create its own glpi-secret Secret and the plaintext
+    # database credentials below (mariadb.auth.* / externalDatabase.*) are ignored by
+    # the application containers (php-fpm, jobs, cronjob). Applies whether mariadb.enabled
+    # is true or false.
+    existingSecret: ""
+
   # -- GLPI Pod Security Context
   # Security settings applied at the pod level
   podSecurityContext:
@@ -247,6 +258,12 @@ mariadb:
     username: glpi
     # Database password for GLPI user
     password: glpi
+    # Name of an existing Secret containing MariaDB server credentials, sourced from an
+    # external secrets manager (Doppler, External Secrets Operator, Vault, etc). Must
+    # contain keys: MARIADB_ROOT_PASSWORD, MARIADB_DATABASE, MARIADB_USER, MARIADB_PASSWORD.
+    # When set, this chart will not create its own mariadb-glpi-secret Secret and the
+    # rootPassword/database/username/password values above are ignored.
+    existingSecret: ""
   
   # Primary database configuration
   primary:


### PR DESCRIPTION
## Problem

MariaDB and GLPI database credentials were only configurable as plaintext
values in values.yaml (mariadb.auth.rootPassword/username/password, etc),
always rendered into chart-managed Secrets. There was no way to point the
chart at a Secret already populated by an external secrets manager
(Doppler, External Secrets Operator, Vault, Sealed Secrets, etc), which
is the standard pattern the Bitnami charts support via
'<component>.auth.existingSecret'.

## Fix

Added two independent existingSecret overrides, following the Bitnami
naming convention:

- mariadb.auth.existingSecret: for the MariaDB server's own credentials
  (needs MARIADB_ROOT_PASSWORD, MARIADB_DATABASE, MARIADB_USER,
  MARIADB_PASSWORD). Used by the MariaDB StatefulSet and the
  mariadb-timezone Job. When set, mariadb-secret.yaml is skipped.

- glpi.database.existingSecret: for the GLPI application's DB credentials
  (needs MARIADB_DATABASE, MARIADB_USER, MARIADB_PASSWORD - no root
  password, preserving the existing least-privilege separation between
  the app-facing secret and the DB-server-facing secret). Used by
  php-fpm, all 5 init Jobs, and the cronjob. When set, glpi-secret.yaml
  is skipped. Applies whether mariadb.enabled is true or false.

Added glpi.mariadbSecretName / glpi.databaseSecretName helpers in
_helpers.tpl that resolve to the existingSecret name when set, or the
chart-managed Secret name otherwise. All secretRef consumers now go
through these helpers instead of hardcoding mariadb-glpi-secret /
glpi-secret.

## Testing

- helm lint: 0 failures
- helm template (default): both glpi-secret and mariadb-glpi-secret created
- helm template --set mariadb.auth.existingSecret=doppler-mariadb-creds:
  mariadb-glpi-secret NOT created; StatefulSet + timezone Job reference
  doppler-mariadb-creds
- helm template --set glpi.database.existingSecret=doppler-glpi-db-creds:
  glpi-secret NOT created; all 8 consumers (php-fpm, nginx, 5 jobs,
  cronjob) reference doppler-glpi-db-creds

