### PR TITLE
feat(chart): isolate MariaDB with a NetworkPolicy

### DIFF
--- a/kubernetes/glpi/templates/glpi-cronjob.yaml
+++ b/kubernetes/glpi/templates/glpi-cronjob.yaml
@@ -14,6 +14,10 @@ spec:
   jobTemplate:
     spec:
       template:
+        metadata:
+          labels:
+            {{- include "glpi.selectorLabels" . | nindent 12 }}
+            app.kubernetes.io/component: cronjob
         spec:
           {{- with .Values.imagePullSecrets }}
           imagePullSecrets:

--- a/kubernetes/glpi/templates/glpi-job.yaml
+++ b/kubernetes/glpi/templates/glpi-job.yaml
@@ -14,6 +14,10 @@ metadata:
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 spec:
   template:
+    metadata:
+      labels:
+        {{- include "glpi.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: job
     spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
@@ -80,6 +84,10 @@ metadata:
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 spec:
   template:
+    metadata:
+      labels:
+        {{- include "glpi.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: job
     spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
@@ -169,6 +177,10 @@ metadata:
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 spec:
   template:
+    metadata:
+      labels:
+        {{- include "glpi.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: job
     spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
@@ -258,6 +270,10 @@ metadata:
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 spec:
   template:
+    metadata:
+      labels:
+        {{- include "glpi.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: job
     spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
@@ -347,6 +363,10 @@ metadata:
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 spec:
   template:
+    metadata:
+      labels:
+        {{- include "glpi.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: job
     spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/kubernetes/glpi/templates/mariadb-job.yaml
+++ b/kubernetes/glpi/templates/mariadb-job.yaml
@@ -13,6 +13,10 @@ metadata:
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 spec:
   template:
+    metadata:
+      labels:
+        {{- include "glpi.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: job
     spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/kubernetes/glpi/templates/mariadb-networkpolicy.yaml
+++ b/kubernetes/glpi/templates/mariadb-networkpolicy.yaml
@@ -1,0 +1,48 @@
+{{- if and .Values.mariadb.enabled .Values.mariadb.networkPolicy.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: mariadb-netpol
+  namespace: {{ include "glpi.namespace" . }}
+  labels:
+    {{- include "glpi.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "glpi.selectorLabels" . | nindent 6 }}
+      role: primary
+  policyTypes:
+    - Ingress
+  ingress:
+    # php-fpm: the only long-running workload that talks to the database
+    - from:
+        - podSelector:
+            matchLabels:
+              {{- include "glpi.selectorLabels" . | nindent 14 }}
+              app.kubernetes.io/component: php-fpm
+      ports:
+        - protocol: TCP
+          port: {{ .Values.mariadb.service.port }}
+    # init Jobs (verifyDir, dbInstall, dbUpgrade, dbConfigure, cacheConfigure) and the
+    # mariadb-timezone Job, which run as short-lived batch Pods during install/upgrade
+    - from:
+        - podSelector:
+            matchLabels:
+              {{- include "glpi.selectorLabels" . | nindent 14 }}
+              app.kubernetes.io/component: job
+      ports:
+        - protocol: TCP
+          port: {{ .Values.mariadb.service.port }}
+    # the GLPI maintenance cronjob (front/cron.php), which needs a live DB connection
+    - from:
+        - podSelector:
+            matchLabels:
+              {{- include "glpi.selectorLabels" . | nindent 14 }}
+              app.kubernetes.io/component: cronjob
+      ports:
+        - protocol: TCP
+          port: {{ .Values.mariadb.service.port }}
+    {{- with .Values.mariadb.networkPolicy.extraIngress }}
+    {{- tpl (toYaml .) $ | nindent 4 }}
+    {{- end }}
+{{- end }}

--- a/kubernetes/glpi/values.yaml
+++ b/kubernetes/glpi/values.yaml
@@ -277,6 +277,19 @@ mariadb:
     # Service port for database connections
     port: 3306
 
+  # -- NetworkPolicy Configuration
+  # Isolates the MariaDB pod at the network level: only pods that legitimately need a DB
+  # connection (php-fpm, the init Jobs, the cronjob) can reach it. nginx, redis, and anything
+  # outside the namespace are denied by default.
+  networkPolicy:
+    # Enable or disable the NetworkPolicy restricting access to MariaDB.
+    # Requires a CNI that enforces NetworkPolicy (Calico, Cilium, etc); on CNIs that don't
+    # enforce it, this resource is created but has no effect.
+    enabled: true
+    # Extra ingress rules to merge in (e.g. to allow a backup CronJob or an external
+    # monitoring/backup tool with its own pod labels). Evaluated as a template.
+    extraIngress: []
+
   # -- MariaDB Pod Security Context
   # Security settings applied at the pod level
   podSecurityContext:


### PR DESCRIPTION
## Problem

The MariaDB pod had no network-level access restriction: any pod in the
namespace could reach it on 3306. Nothing enforced that only php-fpm,
the init Jobs, and the cronjob - the only workloads that actually need a
DB connection - could talk to it.

Additionally, none of the batch workloads (the 5 GLPI init Jobs, the
mariadb-timezone Job, and the GLPI CronJob) set any labels on their Pod
template - only on the Job/CronJob object itself, which Kubernetes does
NOT propagate to the Pods it spawns. This meant a NetworkPolicy podSelector
scoped to app.kubernetes.io/component would silently fail to match Job/
CronJob pods, blocking legitimate DB access from install/upgrade hooks
and scheduled cron tasks.

## Fix

- Added pod template metadata.labels (selectorLabels + app.kubernetes.io/component)
  to the Pod template of all 5 glpi-job.yaml Jobs, mariadb-job.yaml, and
  glpi-cronjob.yaml's jobTemplate. This also makes label selectors like
  "kubectl get pods -l app.kubernetes.io/component=job" actually work,
  independent of the NetworkPolicy use case.
- Added templates/mariadb-networkpolicy.yaml: default-deny ingress to
  the MariaDB pod (selected via role: primary) except from pods labeled
  app.kubernetes.io/component in {php-fpm, job, cronjob}, on port 3306.
- Added mariadb.networkPolicy.enabled (default true) and
  mariadb.networkPolicy.extraIngress (for backup tools / external
  monitoring with their own pod labels) to values.yaml. Gated behind
  mariadb.enabled too, since an external database has nothing here to
  protect.

Note: NetworkPolicy is only enforced by CNIs that implement it (Calico,
Cilium, etc). On CNIs that don't (e.g. default kindnet), this resource
is created but has no effect - documented in values.yaml.

## Testing

- helm lint: 0 failures
- helm template: NetworkPolicy renders with 3 ingress rules (php-fpm, job,
  cronjob), all referencing mariadb.service.port
- helm template --set mariadb.networkPolicy.enabled=false: resource not
  rendered
- helm template --set mariadb.enabled=false: resource not rendered
- Verified all 5 glpi-job.yaml Jobs, mariadb-job.yaml, and glpi-cronjob.yaml
  now carry app.kubernetes.io/component on their Pod template (not just
  the Job/CronJob object)

