### PR TITLE
feat(chart): add resourcesPreset support (Bitnami-style resource tiers)

### DIFF
--- a/helm/templates/_helpers.tpl
+++ b/helm/templates/_helpers.tpl
@@ -80,4 +80,64 @@ Return the proper GLPI Nginx image name
 {{- printf "%s:%s" .Values.glpi.nginx.image.repository .Values.glpi.nginx.image.tag }}
 {{- end }}
 
+{{/*
+Return a resource request/limit object for one of a fixed set of size presets
+(nano/micro/small/medium/large/xlarge/2xlarge), following the same tiers used by
+the Bitnami charts (bitnami/common's common.resources.preset) so operators already
+familiar with that convention get predictable numbers here too. Only used as a
+fallback when a component's explicit `resources` value is left empty ({}); an
+explicit `resources` block always takes precedence over the preset.
+Usage: {{ include "glpi.resources.preset" (dict "type" "small") }}
+*/}}
+{{- define "glpi.resources.preset" -}}
+{{- $presets := dict
+  "nano" (dict
+      "requests" (dict "cpu" "100m" "memory" "128Mi")
+      "limits" (dict "cpu" "150m" "memory" "192Mi")
+   )
+  "micro" (dict
+      "requests" (dict "cpu" "250m" "memory" "256Mi")
+      "limits" (dict "cpu" "375m" "memory" "384Mi")
+   )
+  "small" (dict
+      "requests" (dict "cpu" "500m" "memory" "512Mi")
+      "limits" (dict "cpu" "750m" "memory" "768Mi")
+   )
+  "medium" (dict
+      "requests" (dict "cpu" "500m" "memory" "1024Mi")
+      "limits" (dict "cpu" "750m" "memory" "1536Mi")
+   )
+  "large" (dict
+      "requests" (dict "cpu" "1.0" "memory" "2048Mi")
+      "limits" (dict "cpu" "1.5" "memory" "3072Mi")
+   )
+  "xlarge" (dict
+      "requests" (dict "cpu" "1.0" "memory" "3072Mi")
+      "limits" (dict "cpu" "3.0" "memory" "6144Mi")
+   )
+  "2xlarge" (dict
+      "requests" (dict "cpu" "1.0" "memory" "3072Mi")
+      "limits" (dict "cpu" "6.0" "memory" "12288Mi")
+   )
+ }}
+{{- if hasKey $presets .type -}}
+{{- index $presets .type | toYaml -}}
+{{- else -}}
+{{- printf "ERROR: resourcesPreset '%s' invalid. Allowed values are %s" .type (join "," (keys $presets)) | fail -}}
+{{- end -}}
+{{- end }}
+
+{{/*
+Render a component's resources block: uses the explicit `resources` dict if it is
+non-empty, otherwise falls back to `resourcesPreset` (skipped entirely if both are
+unset). Usage: {{- include "glpi.resources" (dict "resources" .Values.glpi.phpfpm.resources "preset" .Values.glpi.phpfpm.resourcesPreset) | nindent 12 }}
+*/}}
+{{- define "glpi.resources" -}}
+{{- if .resources -}}
+{{- toYaml .resources -}}
+{{- else if and .preset (ne .preset "none") -}}
+{{- include "glpi.resources.preset" (dict "type" .preset) -}}
+{{- end -}}
+{{- end }}
+
 

--- a/helm/templates/glpi-deployment.yaml
+++ b/helm/templates/glpi-deployment.yaml
@@ -88,8 +88,11 @@ spec:
             timeoutSeconds: {{ .Values.glpi.phpfpm.readinessProbe.timeoutSeconds }}
             failureThreshold: {{ .Values.glpi.phpfpm.readinessProbe.failureThreshold }}
           {{- end }}
+          {{- $phpfpmRes := include "glpi.resources" (dict "resources" .Values.glpi.phpfpm.resources "preset" .Values.glpi.phpfpm.resourcesPreset) }}
+          {{- if $phpfpmRes }}
           resources:
-            {{- toYaml .Values.glpi.phpfpm.resources | nindent 12 }}
+            {{- $phpfpmRes | nindent 12 }}
+          {{- end }}
       volumes:
         - name: etc
           persistentVolumeClaim:
@@ -196,8 +199,11 @@ spec:
             timeoutSeconds: {{ .Values.glpi.nginx.readinessProbe.timeoutSeconds }}
             failureThreshold: {{ .Values.glpi.nginx.readinessProbe.failureThreshold }}
           {{- end }}
+          {{- $nginxRes := include "glpi.resources" (dict "resources" .Values.glpi.nginx.resources "preset" .Values.glpi.nginx.resourcesPreset) }}
+          {{- if $nginxRes }}
           resources:
-            {{- toYaml .Values.glpi.nginx.resources | nindent 12 }}
+            {{- $nginxRes | nindent 12 }}
+          {{- end }}
       volumes:
         - name: etc
           persistentVolumeClaim:

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -34,6 +34,12 @@ glpi:
     
     # Number of PHP-FPM replicas
     replicaCount: 1
+
+    # Set container resources according to one common preset (allowed values: none, nano,
+    # micro, small, medium, large, xlarge, 2xlarge). Only applied when `resources` below is
+    # left empty ({}). In production, setting `resources` explicitly is recommended over
+    # relying on a preset.
+    resourcesPreset: "none"
     
     # Resource limits and requests for PHP-FPM container
     resources:
@@ -81,6 +87,11 @@ glpi:
     
     # Number of Nginx replicas
     replicaCount: 1
+
+    # Set container resources according to one common preset (allowed values: none, nano,
+    # micro, small, medium, large, xlarge, 2xlarge). Only applied when `resources` below is
+    # left empty ({}).
+    resourcesPreset: "none"
     
     # Resource limits and requests for Nginx container
     resources:


### PR DESCRIPTION
Resources for php-fpm, nginx, mariadb, and redis were only configurable
as full explicit request/limit blocks. Bitnami charts offer a lighter-weight
alternative via a resourcesPreset value (none/nano/micro/small/medium/
large/xlarge/2xlarge) that maps to a predefined table, useful for quick
sizing without hand-writing CPU/memory numbers.

- Added glpi.resources.preset helper in _helpers.tpl with the same
  tiers/values as bitnami/common's common.resources.preset, so operators
  already familiar with that convention get predictable numbers here.
- Added glpi.resources helper: renders the explicit `resources` dict if
  non-empty, otherwise falls back to `resourcesPreset` (renders nothing
  if both are unset/none).
- Added resourcesPreset: "none" alongside the existing resources blocks
  for glpi.phpfpm, glpi.nginx, mariadb.primary, and redis in values.yaml.
  Existing concrete resources values are UNCHANGED and still take
  precedence by default - this is purely additive, zero behavior change
  unless a user explicitly clears `resources` to use a preset instead.
- Updated glpi-deployment.yaml (php-fpm + nginx), mariadb-statefulset.yaml,
  and redis-deployment.yaml to use the new helper.

- helm lint: 0 failures
- helm template (default): resources unchanged (1000m/512Mi php-fpm,
  500m/256Mi nginx, matches pre-existing values)
- helm template --set glpi.phpfpm.resources=null --set
  glpi.phpfpm.resourcesPreset=large: renders 1.5cpu/3072Mi limits,
  1.0cpu/2048Mi requests (matches Bitnami's "large" tier)
- helm template --set redis.resources=null (resourcesPreset stays
  "none" default): no resources block rendered at all

