### PR TITLE
feat(chart): add optional PodDisruptionBudget for php-fpm and nginx

### DIFF
--- a/helm/templates/glpi-poddisruptionbudget.yaml
+++ b/helm/templates/glpi-poddisruptionbudget.yaml
@@ -1,0 +1,42 @@
+{{- if .Values.glpi.phpfpm.pdb.enabled }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: php-fpm
+  namespace: {{ include "glpi.namespace" . }}
+  labels:
+    {{- include "glpi.labels" . | nindent 4 }}
+    app.kubernetes.io/component: php-fpm
+spec:
+  {{- if .Values.glpi.phpfpm.pdb.minAvailable }}
+  minAvailable: {{ .Values.glpi.phpfpm.pdb.minAvailable }}
+  {{- else }}
+  maxUnavailable: {{ .Values.glpi.phpfpm.pdb.maxUnavailable }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "glpi.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: php-fpm
+{{- end }}
+
+---
+{{- if .Values.glpi.nginx.pdb.enabled }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: nginx
+  namespace: {{ include "glpi.namespace" . }}
+  labels:
+    {{- include "glpi.labels" . | nindent 4 }}
+    app.kubernetes.io/component: nginx
+spec:
+  {{- if .Values.glpi.nginx.pdb.minAvailable }}
+  minAvailable: {{ .Values.glpi.nginx.pdb.minAvailable }}
+  {{- else }}
+  maxUnavailable: {{ .Values.glpi.nginx.pdb.maxUnavailable }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "glpi.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: nginx
+{{- end }}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -67,6 +67,20 @@ glpi:
       periodSeconds: 5
       timeoutSeconds: 3
       failureThreshold: 3
+
+    # -- Pod Disruption Budget
+    # Only meaningful when phpfpm.replicaCount > 1: with a single replica, a PDB
+    # requiring minAvailable: 1 (or maxUnavailable: 0) will block voluntary node
+    # drains/evictions entirely, since Kubernetes can never satisfy it. Defaults to
+    # disabled for that reason; enable once you scale replicaCount up.
+    pdb:
+      enabled: false
+      # Minimum number/percentage of pods that must remain available (e.g. 1 or "50%").
+      # Leave empty to use maxUnavailable instead.
+      minAvailable: ""
+      # Maximum number/percentage of pods that may be unavailable (e.g. 1 or "50%").
+      # Ignored if minAvailable is set.
+      maxUnavailable: 1
   
   # Nginx container configuration
   nginx:
@@ -116,6 +130,14 @@ glpi:
       periodSeconds: 5
       timeoutSeconds: 3
       failureThreshold: 3
+
+    # -- Pod Disruption Budget
+    # Only meaningful when nginx.replicaCount > 1 - see the equivalent note under
+    # glpi.phpfpm.pdb.
+    pdb:
+      enabled: false
+      minAvailable: ""
+      maxUnavailable: 1
     
     # Nginx service configuration
     service:


### PR DESCRIPTION
## Problem

Neither php-fpm nor nginx had a PodDisruptionBudget, so there was no
guardrail against voluntary disruptions (node drains, cluster-autoscaler
scale-downs) taking down every replica at once when replicaCount > 1.

## Fix

Added templates/glpi-poddisruptionbudget.yaml with independent PDBs for
php-fpm and nginx, each gated behind its own `pdb.enabled` (default
false). Defaulted to disabled rather than enabled-by-default because the
chart's default replicaCount is 1 for both components, and a PDB
requiring minAvailable: 1 (or maxUnavailable: 0) on a single-replica
workload permanently blocks voluntary evictions - Kubernetes can never
satisfy the budget. This is documented inline in values.yaml. Supports
both minAvailable and maxUnavailable (minAvailable takes precedence when
set).

## Testing

- helm lint: 0 failures
- helm template (default): no PDB rendered
- helm template --set glpi.phpfpm.pdb.enabled=true --set
  glpi.phpfpm.pdb.minAvailable=1 --set glpi.nginx.pdb.enabled=true:
  both PDBs render with correct selectors

