### PR TITLE
feat(chart): add optional HorizontalPodAutoscaler for php-fpm and nginx

### DIFF
--- a/helm/templates/glpi-deployment.yaml
+++ b/helm/templates/glpi-deployment.yaml
@@ -8,7 +8,9 @@ metadata:
     app.kubernetes.io/component: php-fpm
   namespace: {{ include "glpi.namespace" . }}
 spec:
+  {{- if not .Values.glpi.phpfpm.autoscaling.enabled }}
   replicas: {{ .Values.glpi.phpfpm.replicaCount }}
+  {{- end }}
   selector:
     matchLabels:
       {{- include "glpi.selectorLabels" . | nindent 6 }}
@@ -112,7 +114,9 @@ metadata:
     app.kubernetes.io/component: nginx
   namespace: {{ include "glpi.namespace" . }}
 spec:
+  {{- if not .Values.glpi.nginx.autoscaling.enabled }}
   replicas: {{ .Values.glpi.nginx.replicaCount }}
+  {{- end }}
   selector:
     matchLabels:
       {{- include "glpi.selectorLabels" . | nindent 6 }}

--- a/helm/templates/glpi-hpa.yaml
+++ b/helm/templates/glpi-hpa.yaml
@@ -1,0 +1,70 @@
+{{- if .Values.glpi.phpfpm.autoscaling.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: php-fpm
+  namespace: {{ include "glpi.namespace" . }}
+  labels:
+    {{- include "glpi.labels" . | nindent 4 }}
+    app.kubernetes.io/component: php-fpm
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: php-fpm
+  minReplicas: {{ .Values.glpi.phpfpm.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.glpi.phpfpm.autoscaling.maxReplicas }}
+  metrics:
+    {{- if .Values.glpi.phpfpm.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.glpi.phpfpm.autoscaling.targetCPUUtilizationPercentage }}
+    {{- end }}
+    {{- if .Values.glpi.phpfpm.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.glpi.phpfpm.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- end }}
+{{- end }}
+
+---
+{{- if .Values.glpi.nginx.autoscaling.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: nginx
+  namespace: {{ include "glpi.namespace" . }}
+  labels:
+    {{- include "glpi.labels" . | nindent 4 }}
+    app.kubernetes.io/component: nginx
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: nginx
+  minReplicas: {{ .Values.glpi.nginx.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.glpi.nginx.autoscaling.maxReplicas }}
+  metrics:
+    {{- if .Values.glpi.nginx.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.glpi.nginx.autoscaling.targetCPUUtilizationPercentage }}
+    {{- end }}
+    {{- if .Values.glpi.nginx.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.glpi.nginx.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- end }}
+{{- end }}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -32,8 +32,22 @@ glpi:
       # Image pull policy
       pullPolicy: IfNotPresent
     
-    # Number of PHP-FPM replicas
+    # Number of PHP-FPM replicas.
+    # Ignored (Kubernetes/HPA owns the field instead) when autoscaling.enabled is true.
     replicaCount: 1
+
+    # -- Horizontal Pod Autoscaler
+    # Remember the shared-storage caveat: php-fpm reads/writes GLPI_VAR_DIR (uploads,
+    # sessions) on a PVC. Scaling beyond 1 replica requires that PVC to use a
+    # ReadWriteMany-capable storageClass (NFS, CephFS, EFS, etc) - see
+    # glpi.persistence.files.accessMode.
+    autoscaling:
+      enabled: false
+      minReplicas: 1
+      maxReplicas: 5
+      # Leave empty to omit that metric from the HPA entirely.
+      targetCPUUtilizationPercentage: 80
+      targetMemoryUtilizationPercentage: ""
     
     # Resource limits and requests for PHP-FPM container
     resources:
@@ -79,8 +93,17 @@ glpi:
       # Image pull policy
       pullPolicy: IfNotPresent
     
-    # Number of Nginx replicas
+    # Number of Nginx replicas.
+    # Ignored (Kubernetes/HPA owns the field instead) when autoscaling.enabled is true.
     replicaCount: 1
+
+    # -- Horizontal Pod Autoscaler
+    autoscaling:
+      enabled: false
+      minReplicas: 1
+      maxReplicas: 5
+      targetCPUUtilizationPercentage: 80
+      targetMemoryUtilizationPercentage: ""
     
     # Resource limits and requests for Nginx container
     resources:


### PR DESCRIPTION
## Problem

Neither php-fpm nor nginx could scale automatically based on load; only
a fixed replicaCount was supported.

## Fix

- Added templates/glpi-hpa.yaml with independent autoscaling/v2 HPAs for
  php-fpm and nginx, each gated behind its own `autoscaling.enabled`
  (default false). Supports CPU and/or memory utilization targets
  (either can be left empty to omit that metric).
- glpi-deployment.yaml now omits the `replicas` field entirely when
  autoscaling.enabled is true for that component, so `helm upgrade`
  doesn't fight the HPA by resetting replicas back to replicaCount on
  every release (a well-known Helm+HPA footgun otherwise).
- Documented the shared-storage caveat directly in values.yaml: scaling
  php-fpm beyond 1 replica requires glpi.persistence.files to use a
  ReadWriteMany-capable storageClass, since GLPI_VAR_DIR (uploads,
  sessions) is read/written by every replica.

## Testing

- helm lint: 0 failures
- helm template (default): no HPA rendered, Deployments still set
  `replicas: 1` explicitly
- helm template --set glpi.phpfpm.autoscaling.enabled=true --set
  glpi.nginx.autoscaling.enabled=true: both HPAs render targeting the
  correct Deployment names; Deployments no longer set `replicas` at all

