### PR TITLE
feat(chart): add optional readOnlyRootFilesystem hardening (empirically verified)

### DIFF
--- a/helm/templates/glpi-cronjob.yaml
+++ b/helm/templates/glpi-cronjob.yaml
@@ -58,6 +58,10 @@ spec:
                   mountPath: /var/www/html/marketplace
                 - name: etc 
                   mountPath: /etc/glpi
+                {{- if .Values.glpi.securityContext.readOnlyRootFilesystem }}
+                - name: tmp
+                  mountPath: /tmp
+                {{- end }}
               resources:
                 {{- toYaml .Values.glpi.phpfpm.resources | nindent 16 }}
           volumes: 
@@ -70,5 +74,9 @@ spec:
             - name: marketplace
               persistentVolumeClaim:
                 claimName: glpi-marketplace
+            {{- if .Values.glpi.securityContext.readOnlyRootFilesystem }}
+            - name: tmp
+              emptyDir: {}
+            {{- end }}
           restartPolicy: OnFailure
 {{- end }}

--- a/helm/templates/glpi-deployment.yaml
+++ b/helm/templates/glpi-deployment.yaml
@@ -70,6 +70,10 @@ spec:
               mountPath: /etc/glpi
             - name: marketplace
               mountPath: /var/www/html/marketplace
+            {{- if .Values.glpi.securityContext.readOnlyRootFilesystem }}
+            - name: tmp
+              mountPath: /tmp
+            {{- end }}
           {{- if .Values.glpi.phpfpm.livenessProbe.enabled }}
           livenessProbe:
             tcpSocket:
@@ -100,6 +104,10 @@ spec:
         - name: marketplace
           persistentVolumeClaim:
             claimName: glpi-marketplace
+        {{- if .Values.glpi.securityContext.readOnlyRootFilesystem }}
+        - name: tmp
+          emptyDir: {}
+        {{- end }}
 
 
 ---
@@ -176,6 +184,10 @@ spec:
               mountPath: /etc/glpi
             - name: nginx-conf
               mountPath: /etc/nginx/conf.d
+            {{- if .Values.glpi.securityContext.readOnlyRootFilesystem }}
+            - name: tmp
+              mountPath: /tmp
+            {{- end }}
           {{- if .Values.glpi.nginx.livenessProbe.enabled }}
           livenessProbe:
             httpGet:
@@ -212,6 +224,10 @@ spec:
           configMap:
             defaultMode: 420
             name: nginx-conf
+        {{- if .Values.glpi.securityContext.readOnlyRootFilesystem }}
+        - name: tmp
+          emptyDir: {}
+        {{- end }}
 
 
 ---

--- a/helm/templates/glpi-job.yaml
+++ b/helm/templates/glpi-job.yaml
@@ -48,6 +48,10 @@ spec:
               mountPath: /var/www/html/marketplace
             - name: etc
               mountPath: /etc/glpi
+            {{- if .Values.glpi.securityContext.readOnlyRootFilesystem }}
+            - name: tmp
+              mountPath: /tmp
+            {{- end }}
       volumes:
         - name: etc
           persistentVolumeClaim:
@@ -58,6 +62,10 @@ spec:
         - name: marketplace
           persistentVolumeClaim:
             claimName: glpi-marketplace
+        {{- if .Values.glpi.securityContext.readOnlyRootFilesystem }}
+        - name: tmp
+          emptyDir: {}
+        {{- end }}
       restartPolicy: OnFailure
   parallelism: 1
   completions: 1
@@ -137,6 +145,10 @@ spec:
               mountPath: /var/www/html/marketplace
             - name: etc
               mountPath: /etc/glpi
+            {{- if .Values.glpi.securityContext.readOnlyRootFilesystem }}
+            - name: tmp
+              mountPath: /tmp
+            {{- end }}
       volumes:
         - name: etc
           persistentVolumeClaim:
@@ -147,6 +159,10 @@ spec:
         - name: marketplace
           persistentVolumeClaim:
             claimName: glpi-marketplace
+        {{- if .Values.glpi.securityContext.readOnlyRootFilesystem }}
+        - name: tmp
+          emptyDir: {}
+        {{- end }}
       restartPolicy: OnFailure
   parallelism: 1
   completions: 1
@@ -226,6 +242,10 @@ spec:
               mountPath: /var/www/html/marketplace
             - name: etc
               mountPath: /etc/glpi
+            {{- if .Values.glpi.securityContext.readOnlyRootFilesystem }}
+            - name: tmp
+              mountPath: /tmp
+            {{- end }}
       volumes:
         - name: etc
           persistentVolumeClaim:
@@ -236,6 +256,10 @@ spec:
         - name: marketplace
           persistentVolumeClaim:
             claimName: glpi-marketplace
+        {{- if .Values.glpi.securityContext.readOnlyRootFilesystem }}
+        - name: tmp
+          emptyDir: {}
+        {{- end }}
       restartPolicy: OnFailure
   parallelism: 1
   completions: 1
@@ -315,6 +339,10 @@ spec:
               mountPath: /var/lib/glpi
             - name: marketplace
               mountPath: /var/www/html/marketplace
+            {{- if .Values.glpi.securityContext.readOnlyRootFilesystem }}
+            - name: tmp
+              mountPath: /tmp
+            {{- end }}
       volumes:
         - name: etc
           persistentVolumeClaim:
@@ -325,6 +353,10 @@ spec:
         - name: marketplace
           persistentVolumeClaim:
             claimName: glpi-marketplace
+        {{- if .Values.glpi.securityContext.readOnlyRootFilesystem }}
+        - name: tmp
+          emptyDir: {}
+        {{- end }}
       restartPolicy: OnFailure
   parallelism: 1
   completions: 1
@@ -381,6 +413,10 @@ spec:
               mountPath: /var/lib/glpi
             - name: marketplace
               mountPath: /var/www/html/marketplace
+            {{- if .Values.glpi.securityContext.readOnlyRootFilesystem }}
+            - name: tmp
+              mountPath: /tmp
+            {{- end }}
       volumes:
         - name: etc
           persistentVolumeClaim:
@@ -391,6 +427,10 @@ spec:
         - name: marketplace
           persistentVolumeClaim:
             claimName: glpi-marketplace
+        {{- if .Values.glpi.securityContext.readOnlyRootFilesystem }}
+        - name: tmp
+          emptyDir: {}
+        {{- end }}
       restartPolicy: OnFailure
   parallelism: 1
   completions: 1

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -208,7 +208,7 @@ glpi:
     fsGroup: 82
 
   # -- GLPI Container Security Context
-  # Security settings applied at the container level
+  # Security settings applied at the container level (php-fpm, nginx, all init Jobs, cronjob)
   securityContext:
     # Run as non-root user
     runAsNonRoot: true
@@ -218,6 +218,14 @@ glpi:
     capabilities:
       drop:
       - ALL
+    # Mount the container's root filesystem as read-only. Verified against the actual
+    # eftechcombr/glpi:php-fpm and :nginx images (docker run --read-only): php-fpm starts
+    # cleanly with no extra writable paths; nginx needs /tmp writable (proxy_temp etc, used
+    # by nginx-unprivileged's default config). When enabled, this chart mounts an emptyDir
+    # at /tmp on every container that shares this securityContext (php-fpm, nginx, init
+    # Jobs, cronjob) to cover both cases uniformly. GLPI's own data (uploads, sessions,
+    # config, marketplace) already lives on PVCs, unaffected by this setting either way.
+    readOnlyRootFilesystem: false
 
 # -- MariaDB Subchart Configuration
 # Database Configuration (deploys helmforge/mariadb subchart)


### PR DESCRIPTION
## Problem

None of the containers (php-fpm, nginx, mariadb, redis) could run with a
read-only root filesystem, a standard hardening control (reduces the
blast radius of a container compromise: an attacker can't write a
webshell or modify binaries even with code execution).

## Approach

Rather than guessing which paths need to stay writable, each image was
tested directly with `docker run --read-only` (and, for the final pass,
combined with the exact runAsUser/capabilities this chart already sets)
to get ground truth instead of assumptions:

- eftechcombr/glpi:php-fpm-11.0.8 - starts clean with ZERO extra writable
  paths.
- eftechcombr/glpi:nginx-11.0.8 - fails without /tmp writable
  (`mkdir() "/tmp/proxy_temp" failed (Read-only file system)`); works
  with only /tmp added.
- mariadb:11.4 - fails without /tmp (InnoDB temp files) and /run/mysqld
  (unix socket bind); works with those two plus the existing
  /var/lib/mysql PVC. Verified with an actual `SELECT 1` after startup.
- redis:7.0-alpine - runs and SAVE succeeds even fully read-only when the
  image's own VOLUME-declared /data gets an implicit writable mount from
  the Docker daemon, but Kubernetes/CRI runtimes don't reliably replicate
  that behavior, so an explicit emptyDir is safer than relying on it.

Final combined validation (uid matching this chart's securityContext,
--cap-drop ALL, --read-only, plus only the specific tmpfs paths listed
above): all four images started/ran cleanly, and mariadb/redis were
exercised with real queries (SELECT 1, SET/GET) to confirm they weren't
just booting but functioning.

## Fix

- Added `readOnlyRootFilesystem: false` (opt-in, not default-on) to
  glpi.securityContext, mariadb.securityContext, and redis.securityContext
  in values.yaml, each documented with exactly which paths the chart
  mounts when enabled and why.
- When glpi.securityContext.readOnlyRootFilesystem is true: mounts an
  emptyDir at /tmp on php-fpm, nginx, all 5 init Jobs, and the cronjob
  (they all share this securityContext).
- When mariadb.securityContext.readOnlyRootFilesystem is true: mounts
  emptyDirs at /tmp and /run/mysqld on the MariaDB StatefulSet, and /tmp
  on the mariadb-timezone Job.
- When redis.securityContext.readOnlyRootFilesystem is true: mounts an
  emptyDir at /data (Redis has no PVC in this chart either way - it's
  used purely as an ephemeral object cache, so this changes nothing
  about data durability).
- All additions are conditional and add zero volumes/mounts when the
  corresponding flag stays false (the default), so this is a strictly
  additive, opt-in change.

## Testing

- helm lint: 0 failures
- helm template (default): 0 occurrences of the new tmp/data
  volumes/mounts anywhere in the rendered output
- helm template with all three readOnlyRootFilesystem flags set to true:
  correct emptyDir mounts appear on exactly the expected 11 workloads
  (2 Deployments=php-fpm+nginx, 1 Deployment=redis, 6 Jobs=5 glpi jobs +
  mariadb-timezone, 1 CronJob, 1 StatefulSet=mariadb); mariadb gets both
  /tmp and /run/mysqld, redis gets /data
- docker run --read-only --cap-drop ALL --user <matching-uid> against all
  four images individually: all start/run correctly with only the
  documented paths writable; mariadb and redis verified with live
  queries, not just process liveness

