### PR TITLE
chore(redis): bump image tag from 7.0-alpine to 7.4-alpine

### DIFF
--- a/docker/docker-compose-build.yml
+++ b/docker/docker-compose-build.yml
@@ -1,6 +1,6 @@
 services:
   redis: 
-    image: redis:7.0-alpine 
+    image: redis:7.4-alpine 
     restart: unless-stopped
     ports: 
       - 6379:6379

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   redis: 
-    image: redis:7.0-alpine 
+    image: redis:7.4-alpine 
     restart: unless-stopped
     ports: 
       - 6379:6379

--- a/kubernetes/glpi/README.md
+++ b/kubernetes/glpi/README.md
@@ -145,7 +145,7 @@ The following table lists the configurable parameters of the GLPI chart and thei
 |-----------|-------------|---------|
 | `redis.enabled` | Deploy internal Redis for caching | `true` |
 | `redis.image.repository` | Redis image repository | `redis` |
-| `redis.image.tag` | Redis image tag | `"7.0-alpine"` |
+| `redis.image.tag` | Redis image tag | `"7.4-alpine"` |
 | `redis.image.pullPolicy` | Redis image pull policy | `IfNotPresent` |
 | `redis.replicaCount` | Number of Redis replicas | `1` |
 | `redis.resources.limits.cpu` | Redis CPU limit | `500m` |

--- a/kubernetes/glpi/values.yaml
+++ b/kubernetes/glpi/values.yaml
@@ -302,7 +302,7 @@ redis:
     # Image repository for Redis
     repository: redis
     # Image tag for Redis
-    tag: "7.0-alpine"
+    tag: "7.4-alpine"
     # Image pull policy
     pullPolicy: IfNotPresent
   


### PR DESCRIPTION
Updates the default Redis image from 7.0-alpine to 7.4-alpine across
all relevant files:

- kubernetes/glpi/values.yaml: default tag for the Helm chart
- kubernetes/glpi/README.md: documented default value
- docker/docker-compose.yml: local dev compose file
- docker/docker-compose-build.yml: build compose file

Validated end-to-end on a real kind cluster (not just helm template):
- helm install completed successfully, all pods Ready
- Redis container confirmed running redis:7.4-alpine (v7.4.9)
- GLPI connected to Redis via CACHE_DSN, SET/GET/DEL operations OK
- GLPI actively stores cache keys (core:*) in Redis
- HTTP 200 with real GLPI login page served correctly

