### PR TITLE
feat(helm): add externalCache configuration

### DIFF
--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: glpi
 description: GLPI Helm Chart - IT Asset Management and Service Desk
 type: application
-version: 2.11.0
+version: 2.11.1
 appVersion: "11.0.8"
 
 dependencies:

--- a/helm/README.md
+++ b/helm/README.md
@@ -96,7 +96,7 @@ The following table lists the configurable parameters of the GLPI chart and thei
 | `glpi.jobs.dbInstall.enabled` | Install GLPI database schema (fresh installs) | `true` |
 | `glpi.jobs.dbUpgrade.enabled` | Upgrade GLPI database schema (upgrades) | `true` |
 | `glpi.jobs.dbConfigure.enabled` | Configure GLPI database connection | `true` |
-| `glpi.jobs.cacheConfigure.enabled` | Configure GLPI cache settings (Valkey) | `true` |
+| `glpi.jobs.cacheConfigure.enabled` | Configure GLPI cache settings | `true` |
 
 ### CronJob
 
@@ -186,6 +186,15 @@ Valkey (Redis-compatible fork) replaces the previously inlined Redis deployment.
 | `externalDatabase.username` | External database username | `""` |
 | `externalDatabase.password` | External database password | `""` |
 
+### External Cache
+
+| Parameter | Description | Default |
+|-----------|-------------|---------|
+| `externalCache.host` | External Redis/Valkey hostname | `""` |
+| `externalCache.port` | External Redis/Valkey port | `6379` |
+| `externalCache.password` | External Redis/Valkey password | `""` |
+| `externalCache.tls` | Enable TLS (rediss://) | `false` |
+
 ### Service Account
 
 | Parameter | Description | Default |
@@ -232,6 +241,23 @@ externalDatabase:
   database: glpi
   username: glpi
   password: mySecurePassword
+```
+
+## Cache
+
+By default, the chart deploys Valkey (a Redis-compatible fork) via the [helmforge/valkey](https://artifacthub.io/packages/helm/helmforge/valkey) subchart. The internal cache service is reachable at `{release-name}-valkey-client.{namespace}.svc.cluster.local:6379`.
+
+To use an external Redis/Valkey instance, disable the built-in Valkey and configure `externalCache`:
+
+```yaml
+valkey:
+  enabled: false
+
+externalCache:
+  host: my-redis.example.com
+  port: 6379
+  password: myCachePassword
+  tls: false
 ```
 
 ## Initialization Jobs

--- a/helm/templates/glpi-configmap.yaml
+++ b/helm/templates/glpi-configmap.yaml
@@ -36,6 +36,10 @@ data:
   {{- if .Values.valkey.enabled }}
   {{- $valkeyPort := .Values.valkey.service.port | default 6379 | toString }}
   CACHE_DSN: {{ printf "redis://%s-valkey-client:%s" .Release.Name $valkeyPort | quote }}
+  {{- else if .Values.externalCache.host }}
+  {{- $scheme := "redis" }}
+  {{- if .Values.externalCache.tls }}{{ $scheme = "rediss" }}{{ end }}
+  CACHE_DSN: {{ printf "%s://%s:%s" $scheme .Values.externalCache.host (.Values.externalCache.port | default 6379 | toString) | quote }}
   {{- end }}
 
 ---

--- a/helm/templates/glpi-secret.yaml
+++ b/helm/templates/glpi-secret.yaml
@@ -16,3 +16,8 @@ data:
   MARIADB_USER: {{ .Values.externalDatabase.username | b64enc | quote }}
   MARIADB_PASSWORD: {{ .Values.externalDatabase.password | b64enc | quote }}
   {{- end }}
+  {{- if and (not .Values.valkey.enabled) .Values.externalCache.host .Values.externalCache.password }}
+  {{- $scheme := "redis" }}
+  {{- if .Values.externalCache.tls }}{{ $scheme = "rediss" }}{{ end }}
+  CACHE_DSN: {{ printf "%s://:%s@%s:%s" $scheme .Values.externalCache.password .Values.externalCache.host (.Values.externalCache.port | default 6379 | toString) | b64enc | quote }}
+  {{- end }}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -454,3 +454,15 @@ externalDatabase:
   username: ""
   # External database password
   password: ""
+
+# -- External Cache Configuration
+# Used when valkey.enabled is false
+externalCache:
+  # External Redis/Valkey hostname or IP
+  host: ""
+  # External Redis/Valkey port
+  port: 6379
+  # External Redis/Valkey password (leave empty if no auth)
+  password: ""
+  # Enable TLS for cache connection (rediss://)
+  tls: false


### PR DESCRIPTION
Add `externalCache` configuration to the Helm chart, mirroring the existing `externalDatabase` pattern. This allows users to point GLPI at an external Redis/Valkey instance when `valkey.enabled` is `false`.

### Changes

| File | Change |
|------|--------|
| `helm/values.yaml` | New `externalCache` block: `host`, `port`, `password`, `tls` |
| `helm/templates/glpi-configmap.yaml` | `CACHE_DSN` falls back to `externalCache` (without password) |
| `helm/templates/glpi-secret.yaml` | `CACHE_DSN` with password in Secret (overrides ConfigMap when password is set) |
| `helm/README.md` | Parameter table + Cache usage section with example |

### How it works

The Secret overrides the ConfigMap via `envFrom` ordering (Secret is second):

| Scenario | ConfigMap `CACHE_DSN` | Secret `CACHE_DSN` | Effective value |
|----------|----------------------|--------------------|----------------|
| `valkey.enabled: true` | `redis://release-vk:6379` | — | `redis://release-vk:6379` |
| `externalCache` no password | `redis://host:6379` | — | `redis://host:6379` |
| `externalCache` with password | `redis://host:6379` | `redis://:pass@host:6379` | `redis://:pass@host:6379` |
| With TLS + password | `rediss://host:6379` | `rediss://:pass@host:6379` | `rediss://:pass@host:6379` |

### Validation

- `helm lint` — 0 failures
- `helm install --dry-run` — templates render correctly for both default and externalCache paths
- `helm install` (real) — `STATUS: deployed` with ConfigMap and Secret values matching expected