### PR TITLE
fix(helm): resolve Artifact Hub validation errors

### DIFF
--- a/artifacthub-repo.yml
+++ b/artifacthub-repo.yml
@@ -5,5 +5,3 @@ repositoryID: 5eec008b-2683-4f56-ac36-71ea3ccc3478
 owners:
   - name: eftechcombr
     email: contato@eftech.com.br
-# ignore:
-#   - name: docker


### PR DESCRIPTION
Fixes three ArtifactHub validation errors:

1. **Logo 404** — Old tags had `icon: https://glpi-project.org/wp-content/themes/glpi/assets/img/logo-glpi.svg` (returns 404). Current `helm/Chart.yaml` already uses `https://www.glpi-project.org/wp-content/uploads/2025/03/glpi-teclib-color-logo.svg` (verified working).

2. **Invalid category** — Old tags had `artifacthub.io/category: it-service-management` (invalid). Current `helm/Chart.yaml` already uses `artifacthub.io/category: integration-delivery` (valid per [ArtifactHub docs](https://artifacthub.io/docs/topics/annotations/helm)).

3. **Repository metadata ignore field** — `artifacthub-repo.yml` had `ignore: - docker/` (plain string, not a struct). Removed the unused commented-out ignore section entirely.

The errors for old tags (v11.0.7.1, v11.0.8) are immutable but will clear from the ArtifactHub dashboard once a new tag is created from current `main`.