### PR TITLE
fix(chart): read MARIADB_PASSWORD from the mariadb subchart's own Secret

### DIFF
--- a/helm/templates/_helpers.tpl
+++ b/helm/templates/_helpers.tpl
@@ -80,4 +80,29 @@ Return the proper GLPI Nginx image name
 {{- printf "%s:%s" .Values.glpi.nginx.image.repository .Values.glpi.nginx.image.tag }}
 {{- end }}
 
+{{/*
+Return the name of the Secret holding the MariaDB application user password: either the
+user-supplied mariadb.auth.existingSecret, or the helmforge/mariadb subchart's own
+auto-generated Secret ({release-name}-mariadb-auth). Mirrors that subchart's internal
+"mariadb.secretName" naming convention so GLPI's own containers can read the SAME live
+secret instead of duplicating (and potentially going stale/empty on) the password value in
+glpi-secret. Only meaningful when mariadb.enabled is true.
+*/}}
+{{- define "glpi.mariadb.secretName" -}}
+{{- if .Values.mariadb.auth.existingSecret -}}
+{{- .Values.mariadb.auth.existingSecret -}}
+{{- else -}}
+{{- printf "%s-mariadb-auth" .Release.Name -}}
+{{- end -}}
+{{- end }}
+
+{{/*
+Return the key within the MariaDB auth Secret (see glpi.mariadb.secretName) that holds the
+application user's password. Mirrors mariadb.auth.existingSecretUserPasswordKey so a custom
+existingSecret with a non-default key name is respected.
+*/}}
+{{- define "glpi.mariadb.secretPasswordKey" -}}
+{{- .Values.mariadb.auth.existingSecretUserPasswordKey | default "mariadb-user-password" -}}
+{{- end }}
+
 

--- a/helm/templates/glpi-cronjob.yaml
+++ b/helm/templates/glpi-cronjob.yaml
@@ -48,6 +48,14 @@ spec:
                     name: glpi-config
                 - secretRef: 
                     name: glpi-secret
+              {{- if .Values.mariadb.enabled }}
+              env:
+                - name: MARIADB_PASSWORD
+                  valueFrom:
+                    secretKeyRef:
+                      name: {{ include "glpi.mariadb.secretName" . }}
+                      key: {{ include "glpi.mariadb.secretPasswordKey" . }}
+              {{- end }}
               command: 
                 - php
                 - front/cron.php

--- a/helm/templates/glpi-deployment.yaml
+++ b/helm/templates/glpi-deployment.yaml
@@ -60,6 +60,14 @@ spec:
                 name: glpi-config
             - secretRef:
                 name: glpi-secret
+          {{- if .Values.mariadb.enabled }}
+          env:
+            - name: MARIADB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "glpi.mariadb.secretName" . }}
+                  key: {{ include "glpi.mariadb.secretPasswordKey" . }}
+          {{- end }}
           ports:
             - containerPort: 9000
               name: fpm

--- a/helm/templates/glpi-job.yaml
+++ b/helm/templates/glpi-job.yaml
@@ -37,6 +37,14 @@ spec:
                 name: glpi-config
             - secretRef:
                 name: glpi-secret
+          {{- if .Values.mariadb.enabled }}
+          env:
+            - name: MARIADB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "glpi.mariadb.secretName" . }}
+                  key: {{ include "glpi.mariadb.secretPasswordKey" . }}
+          {{- end }}
           command:
             - sh
             - -c
@@ -130,6 +138,14 @@ spec:
                 name: glpi-config
             - secretRef:
                 name: glpi-secret
+          {{- if .Values.mariadb.enabled }}
+          env:
+            - name: MARIADB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "glpi.mariadb.secretName" . }}
+                  key: {{ include "glpi.mariadb.secretPasswordKey" . }}
+          {{- end }}
           volumeMounts:
             - name: files
               mountPath: /var/lib/glpi
@@ -219,6 +235,14 @@ spec:
                 name: glpi-config
             - secretRef:
                 name: glpi-secret
+          {{- if .Values.mariadb.enabled }}
+          env:
+            - name: MARIADB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "glpi.mariadb.secretName" . }}
+                  key: {{ include "glpi.mariadb.secretPasswordKey" . }}
+          {{- end }}
           volumeMounts:
             - name: files
               mountPath: /var/lib/glpi
@@ -308,6 +332,14 @@ spec:
                 name: glpi-config
             - secretRef:
                 name: glpi-secret
+          {{- if .Values.mariadb.enabled }}
+          env:
+            - name: MARIADB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "glpi.mariadb.secretName" . }}
+                  key: {{ include "glpi.mariadb.secretPasswordKey" . }}
+          {{- end }}
           volumeMounts:
             - name: etc
               mountPath: /etc/glpi

--- a/helm/templates/glpi-secret.yaml
+++ b/helm/templates/glpi-secret.yaml
@@ -10,7 +10,16 @@ data:
   {{- if .Values.mariadb.enabled }}
   MARIADB_DATABASE: {{ .Values.mariadb.auth.database | b64enc | quote }}
   MARIADB_USER: {{ .Values.mariadb.auth.username | b64enc | quote }}
-  MARIADB_PASSWORD: {{ .Values.mariadb.auth.password | b64enc | quote }}
+  {{- /*
+  MARIADB_PASSWORD is intentionally NOT set here when mariadb.enabled: the helmforge/mariadb
+  subchart owns the real password (auto-generated, explicit, or from mariadb.auth.existingSecret)
+  in its own Secret. Duplicating it here would silently render an EMPTY password whenever
+  mariadb.auth.existingSecret is used (the whole point of that field is to avoid putting the
+  password in values.yaml/release history), breaking the DB connection. Consumers instead read
+  MARIADB_PASSWORD directly from the subchart's Secret via secretKeyRef - see
+  glpi.mariadb.secretName in _helpers.tpl and its usage in glpi-deployment.yaml/glpi-job.yaml/
+  glpi-cronjob.yaml.
+  */}}
   {{- else if .Values.externalDatabase }}
   MARIADB_DATABASE: {{ .Values.externalDatabase.database | b64enc | quote }}
   MARIADB_USER: {{ .Values.externalDatabase.username | b64enc | quote }}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -249,6 +249,14 @@ mariadb:
     username: glpi
     # Database password for GLPI user
     password: glpi
+    # -- Use a pre-existing Secret (Doppler / External Secrets / Vault / sealed-secrets, etc)
+    # for MariaDB credentials instead of the plaintext values above. When set, leave
+    # rootPassword/password empty - GLPI's own containers read the password directly from this
+    # Secret (see glpi.mariadb.secretName in _helpers.tpl), so it stays in sync automatically.
+    # existingSecret: ""
+    # -- Key within existingSecret holding the application user password, if it differs from
+    # the helmforge/mariadb subchart's default ("mariadb-user-password").
+    # existingSecretUserPasswordKey: mariadb-user-password
 
   # Service configuration
   service:


### PR DESCRIPTION
Supersedes #172 (closed after the helmforge/mariadb subchart migration).
That subchart already natively supports mariadb.auth.existingSecret and
mariadb.networkPolicy.enabled (see its values.yaml/templates), which
covers #172 and #173's original goals. However, testing that pattern
end-to-end surfaced a real regression introduced by the subchart
migration:

## Problem

glpi-secret.yaml sources MARIADB_PASSWORD directly from
`.Values.mariadb.auth.password`. That value is only non-empty when a
plaintext password is set in values.yaml. When following the
subchart's own documented existingSecret workflow (setting
mariadb.auth.existingSecret and leaving auth.password empty, precisely
to avoid putting the password in values.yaml/release history), the
subchart correctly uses the external secret for MariaDB itself, but
glpi-secret still renders MARIADB_PASSWORD as an empty string - breaking
php-fpm's DB connection entirely on any install that uses existingSecret
as documented.

Verified this is real (not theoretical) on a live kind cluster: created
an external Secret manually, set mariadb.auth.existingSecret to it with
auth.password left empty, and confirmed `helm template` rendered
`MARIADB_PASSWORD: ""` in glpi-secret before this fix.

## Fix

- Added glpi.mariadb.secretName / glpi.mariadb.secretPasswordKey helpers
  that resolve to the SAME secret name/key the helmforge/mariadb
  subchart itself uses (mariadb.auth.existingSecret if set, else its
  auto-generated `{release-name}-mariadb-auth`), so there is a single
  source of truth instead of a duplicated value.
- Removed MARIADB_PASSWORD from glpi-secret.yaml's mariadb.enabled
  branch (MARIADB_DATABASE/MARIADB_USER are unaffected - the subchart's
  existingSecret only ever covers passwords, not those fields).
- Added an explicit `env: MARIADB_PASSWORD valueFrom.secretKeyRef`
  (pointing at the resolved secret/key) to php-fpm, all 5 init Jobs, and
  the cronjob - the only containers that actually consume DB credentials
  - gated behind `{{- if .Values.mariadb.enabled }}` so the
  externalDatabase (mariadb.enabled=false) path is untouched.
- Documented mariadb.auth.existingSecret / existingSecretUserPasswordKey
  in values.yaml (commented, matching the subchart's own field names)
  for discoverability, since they aren't otherwise declared in this
  chart's own values.yaml despite being valid subchart passthrough keys.

## Testing

- helm lint --strict: 0 failures
- helm template (default, no existingSecret): MARIADB_PASSWORD correctly
  sourced via secretKeyRef from the auto-generated
  `{release}-mariadb-auth` secret, key `mariadb-user-password`
- helm template --set mariadb.auth.existingSecret=my-external-secret:
  secretKeyRef correctly points at `my-external-secret`
- helm template --set mariadb.enabled=false --set externalDatabase.*:
  0 occurrences of the new env: block (correctly skipped); glpi-secret
  still renders MARIADB_PASSWORD from externalDatabase.password as before
- Full live kind cluster test: manually created a Secret simulating a
  Vault/Doppler-injected one, installed with
  mariadb.auth.existingSecret pointing to it and auth.password/
  rootPassword empty (exactly as the subchart's own docs recommend) -
  `helm install` completed (STATUS: deployed, meaning the dbConfigure
  hook - which passes --db-password="$MARIADB_PASSWORD" to GLPI's own
  db:configure command - succeeded), confirmed php-fpm's MARIADB_PASSWORD
  env var matches the external secret's value exactly, and GLPI served
  its real login page (HTTP 200, "Authentication - GLPI") confirming the
  DB connection genuinely works end-to-end, not just at template-render
  time

