### PR TITLE
feat(chart): add priorityClassName support for GLPI-owned pods

### DIFF
--- a/helm/templates/glpi-cronjob.yaml
+++ b/helm/templates/glpi-cronjob.yaml
@@ -23,6 +23,9 @@ spec:
           securityContext:
             {{- toYaml . | nindent 12 }}
           {{- end }}
+          {{- with .Values.priorityClassName }}
+          priorityClassName: {{ . }}
+          {{- end }}
           {{- with .Values.nodeSelector }}
           nodeSelector:
             {{- toYaml . | nindent 12 }}

--- a/helm/templates/glpi-deployment.yaml
+++ b/helm/templates/glpi-deployment.yaml
@@ -35,6 +35,9 @@ spec:
       securityContext:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.priorityClassName }}
+      priorityClassName: {{ . }}
+      {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
@@ -138,6 +141,9 @@ spec:
       {{- with .Values.glpi.podSecurityContext }}
       securityContext:
         {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.priorityClassName }}
+      priorityClassName: {{ . }}
       {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:

--- a/helm/templates/glpi-job.yaml
+++ b/helm/templates/glpi-job.yaml
@@ -24,6 +24,9 @@ spec:
       securityContext:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.priorityClassName }}
+      priorityClassName: {{ . }}
+      {{- end }}
       containers:
         - image: {{ include "glpi.phpfpm.image" . }}
           imagePullPolicy: {{ .Values.glpi.phpfpm.image.pullPolicy }}
@@ -89,6 +92,9 @@ spec:
       {{- with .Values.glpi.podSecurityContext }}
       securityContext:
         {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.priorityClassName }}
+      priorityClassName: {{ . }}
       {{- end }}
       initContainers:
         - name: wait-for-mariadb
@@ -179,6 +185,9 @@ spec:
       securityContext:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.priorityClassName }}
+      priorityClassName: {{ . }}
+      {{- end }}
       initContainers:
         - name: wait-for-mariadb
           image: busybox:1.36.1
@@ -268,6 +277,9 @@ spec:
       securityContext:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.priorityClassName }}
+      priorityClassName: {{ . }}
+      {{- end }}
       initContainers:
         - name: wait-for-mariadb
           image: busybox:1.36.1
@@ -356,6 +368,9 @@ spec:
       {{- with .Values.glpi.podSecurityContext }}
       securityContext:
         {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.priorityClassName }}
+      priorityClassName: {{ . }}
       {{- end }}
       containers:
         - image: {{ include "glpi.phpfpm.image" . }}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -432,6 +432,17 @@ podAnnotations: {}
 # Labels to add to GLPI pods
 podLabels: {}
 
+# -- Priority Class Name
+# Assign a PriorityClass to all GLPI-owned pods (php-fpm, nginx, the init Jobs, and the
+# cronjob). Useful to protect the init Jobs (dbInstall/dbConfigure/etc) from eviction or
+# scheduling starvation under node pressure during install/upgrade, and/or to keep GLPI
+# itself running preferentially over lower-priority workloads. Must reference a
+# PriorityClass that already exists in the cluster (this chart does not create one).
+# Example: "system-cluster-critical" or a custom PriorityClass name.
+# To also prioritize the database/cache tier, set mariadb.priorityClassName and/or
+# valkey.priorityClassName - both subcharts already support this independently.
+priorityClassName: ""
+
 # -- Node Selector
 # Node labels for pod assignment
 # Example:


### PR DESCRIPTION
## Problem

The chart had no way to assign a PriorityClass to any of its pods.
Under node pressure (resource contention, memory/CPU eviction), all
GLPI workloads compete on equal footing with everything else in the
cluster - including the init Jobs that install/upgrade/configure the
database and cache, which GLPI depends on completing successfully
during every install/upgrade.

## Fix

Added a top-level `priorityClassName: ""` value (alongside the existing
nodeSelector/tolerations/affinity globals) and wired it into every
GLPI-owned pod spec: php-fpm and nginx Deployments, all 5 init Jobs
(verifyDir, dbInstall, dbUpgrade, dbConfigure, cacheConfigure), and the
cronjob. Purely additive/opt-in - omitted entirely from the rendered
manifests when left empty (the default).

Notably, the 5 init Jobs didn't previously have nodeSelector/tolerations/
affinity support either, so priorityClassName is the first pod-placement
control available there - arguably more valuable there than on the
long-running Deployments, since a starved/evicted init Job blocks the
whole install/upgrade from completing.

Does not touch the mariadb/valkey subcharts - both already expose their
own `mariadb.priorityClassName` / `valkey.priorityClassName` natively,
documented inline for discoverability so operators can prioritize the
whole stack if needed.

## Testing

- helm lint --strict: 0 failures
- helm template (default): 0 occurrences of priorityClassName anywhere
- helm template --set priorityClassName=my-priority-class: exactly 8
  occurrences, one per GLPI-owned workload (2 Deployments + 5 Jobs + 1
  CronJob); confirmed zero leakage into the mariadb/valkey subchart pods
- Full live kind cluster test: created a real PriorityClass
  (glpi-high-priority, value 100000), installed with
  priorityClassName=glpi-high-priority - `helm install` completed
  (STATUS: deployed), confirmed via `kubectl get pod -o
  jsonpath='{.spec.priorityClassName} {.spec.priority}'` that
  Kubernetes actually resolved and applied the real priority value
  (100000) on both php-fpm and nginx pods, and mariadb/valkey pods
  correctly show no priorityClassName at all
- Re-ran `helm upgrade` and observed the init Jobs and cronjob live via
  `kubectl get pods -o custom-columns=...PRIORITY_CLASS...`: all of
  glpi-verify-dir, glpi-db-upgrade, glpi-db-configure, and the cronjob
  showed PRIORITY_CLASS=glpi-high-priority with STATUS=Succeeded

