### PR TITLE
fix(helm): repair chart template and CI lint dependencies

### DIFF
--- a/.github/workflows/helm-publish.yaml
+++ b/.github/workflows/helm-publish.yaml
@@ -35,6 +35,14 @@ jobs:
       - name: Install Helm
         uses: azure/setup-helm@v5
 
+      - name: Add Helm repositories
+        run: |
+          helm repo add helmforge https://repo.helmforge.dev
+          helm repo update
+
+      - name: Build chart dependencies
+        run: helm dependency build ${{ env.CHART_DIR }}
+
       - name: Lint Helm chart
         run: helm lint ${{ env.CHART_DIR }}
 

--- a/helm/templates/_helpers.tpl
+++ b/helm/templates/_helpers.tpl
@@ -124,6 +124,10 @@ Usage: {{ include "glpi.resources.preset" (dict "type" "small") }}
 {{- index $presets .type | toYaml -}}
 {{- else -}}
 {{- printf "ERROR: resourcesPreset '%s' invalid. Allowed values are %s" .type (join "," (keys $presets)) | fail -}}
+{{- end }}
+{{- end }}
+
+{{/*
 Return the name of the Secret holding the MariaDB application user password: either the
 user-supplied mariadb.auth.existingSecret, or the helmforge/mariadb subchart's own
 auto-generated Secret ({release-name}-mariadb-auth). Mirrors that subchart's internal
@@ -150,6 +154,9 @@ unset). Usage: {{- include "glpi.resources" (dict "resources" .Values.glpi.phpfp
 {{- else if and .preset (ne .preset "none") -}}
 {{- include "glpi.resources.preset" (dict "type" .preset) -}}
 {{- end -}}
+{{- end }}
+
+{{/*
 Return the key within the MariaDB auth Secret (see glpi.mariadb.secretName) that holds the
 application user's password. Mirrors mariadb.auth.existingSecretUserPasswordKey so a custom
 existingSecret with a non-default key name is respected.


### PR DESCRIPTION
## Summary

Fixes the failing `helm lint` step in the `helm-publish.yaml` GitHub Action.

## Root causes

1. **Template parse error** in `helm/templates/_helpers.tpl`:
   - The `glpi.resources.preset` and `glpi.resources` `define` blocks were missing their closing `{{- end }}` delimiters.
   - The following `{{/* ... */}}` comment blocks had lost their `{{/*` opener, leaving stray raw text and a dangling `*/}}` inside the template body.
   - Result: `unexpected <define> in command` at line 134 during `helm lint`.
   - Fix: restore the missing `{{- end }}` closers and `{{/*` comment openers. No behavioral change to rendered output.

2. **Missing chart dependencies warning** (`valkey, mariadb`):
   - The lint job ran `helm lint` without building dependencies, even though the chart declares the `helmforge` valkey/mariadb subcharts.
   - Fix: add `helm repo add helmforge` + `helm dependency build` to the lint job, mirroring the existing package/publish jobs.

## Verification

```
helm dependency build helm/
helm lint helm/
# 1 chart(s) linted, 0 chart(s) failed
```

## Test plan

- [ ] `helm lint` job passes on this PR
- [ ] Package/publish jobs unaffected