### PR TITLE
feat(chart): add files backup CronJob to S3-compatible storage (closes #1)

### DIFF
--- a/helm/templates/_helpers.tpl
+++ b/helm/templates/_helpers.tpl
@@ -165,4 +165,39 @@ existingSecret with a non-default key name is respected.
 {{- .Values.mariadb.auth.existingSecretUserPasswordKey | default "mariadb-user-password" -}}
 {{- end }}
 
+{{/*
+Return the name of the Secret holding S3 credentials for the files backup CronJob: either the
+user-supplied glpi.backup.s3.existingSecret, or this chart's own generated Secret. Mirrors the
+same existingSecret-or-generated pattern (and naming convention) as the helmforge/mariadb
+subchart's own backup.s3.existingSecret / mariadb.backupSecretName.
+*/}}
+{{- define "glpi.backup.secretName" -}}
+{{- if .Values.glpi.backup.s3.existingSecret -}}
+{{- .Values.glpi.backup.s3.existingSecret -}}
+{{- else -}}
+{{- printf "%s-backup" (include "glpi.fullname" .) -}}
+{{- end -}}
+{{- end }}
+
+{{/*
+Validates required S3 settings and returns a non-empty string when the files backup CronJob
+should be rendered. Mirrors the helmforge/mariadb subchart's own mariadb.backupEnabled
+fail-fast validation (missing endpoint/bucket at install time is a much clearer error than
+a CronJob silently failing every run).
+*/}}
+{{- define "glpi.backup.enabled" -}}
+{{- if .Values.glpi.backup.enabled -}}
+  {{- if not .Values.glpi.backup.s3.endpoint -}}
+    {{- fail "glpi.backup.s3.endpoint is required when glpi.backup.enabled is true" -}}
+  {{- end -}}
+  {{- if not .Values.glpi.backup.s3.bucket -}}
+    {{- fail "glpi.backup.s3.bucket is required when glpi.backup.enabled is true" -}}
+  {{- end -}}
+  {{- if not (or .Values.glpi.backup.volumes.files .Values.glpi.backup.volumes.marketplace .Values.glpi.backup.volumes.etc) -}}
+    {{- fail "glpi.backup.enabled is true but glpi.backup.volumes.files/marketplace/etc are all false - nothing to back up" -}}
+  {{- end -}}
+  true
+{{- end -}}
+{{- end }}
+
 

--- a/helm/templates/glpi-backup-configmap.yaml
+++ b/helm/templates/glpi-backup-configmap.yaml
@@ -1,0 +1,34 @@
+{{- if include "glpi.backup.enabled" . }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "glpi.fullname" . }}-backup-scripts
+  namespace: {{ include "glpi.namespace" . }}
+  labels:
+    {{- include "glpi.labels" . | nindent 4 }}
+data:
+  glpi-backup.sh: |
+    #!/bin/sh
+    set -eu
+    timestamp="$(date -u +%Y%m%dT%H%M%SZ)"
+    archive="/backup/out/${BACKUP_ARCHIVE_PREFIX}-files-${timestamp}.tar.gz"
+    mkdir -p /backup/out
+    cd /backup/source
+    # Only whichever of files/marketplace/etc were mounted (per glpi.backup.volumes.*) show up
+    # here - tar whatever exists, so a single script works regardless of which are enabled.
+    tar -czf "${archive}" -- *
+    printf "%s" "${archive}" > /backup/out/backup-file
+  upload-backup.sh: |
+    #!/bin/sh
+    set -eu
+    archive="$(cat /backup/out/backup-file)"
+    target="backup/${S3_BUCKET}"
+    if [ -n "${S3_PREFIX:-}" ]; then
+      target="${target}/${S3_PREFIX}"
+    fi
+    mc alias set backup "${S3_ENDPOINT}" "${S3_ACCESS_KEY}" "${S3_SECRET_KEY}"
+    if [ "${S3_CREATE_BUCKET_IF_NOT_EXISTS}" = "true" ]; then
+      mc mb --ignore-existing "backup/${S3_BUCKET}"
+    fi
+    mc cp "${archive}" "${target}/"
+{{- end }}

--- a/helm/templates/glpi-backup-cronjob.yaml
+++ b/helm/templates/glpi-backup-cronjob.yaml
@@ -1,0 +1,136 @@
+{{- if include "glpi.backup.enabled" . }}
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: {{ include "glpi.fullname" . }}-backup
+  namespace: {{ include "glpi.namespace" . }}
+  labels:
+    {{- include "glpi.labels" . | nindent 4 }}
+    app.kubernetes.io/component: backup
+spec:
+  schedule: {{ .Values.glpi.backup.schedule | quote }}
+  suspend: {{ .Values.glpi.backup.suspend }}
+  concurrencyPolicy: {{ .Values.glpi.backup.concurrencyPolicy }}
+  successfulJobsHistoryLimit: {{ .Values.glpi.backup.successfulJobsHistoryLimit }}
+  failedJobsHistoryLimit: {{ .Values.glpi.backup.failedJobsHistoryLimit }}
+  jobTemplate:
+    spec:
+      backoffLimit: {{ .Values.glpi.backup.backoffLimit }}
+      template:
+        metadata:
+          labels:
+            {{- include "glpi.selectorLabels" . | nindent 12 }}
+            app.kubernetes.io/component: backup
+        spec:
+          restartPolicy: Never
+          {{- with .Values.imagePullSecrets }}
+          imagePullSecrets:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.glpi.podSecurityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.priorityClassName }}
+          priorityClassName: {{ . }}
+          {{- end }}
+          {{- with .Values.nodeSelector }}
+          nodeSelector:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.tolerations }}
+          tolerations:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.affinity }}
+          affinity:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          initContainers:
+            - name: glpi-backup
+              image: {{ include "glpi.phpfpm.image" . }}
+              imagePullPolicy: {{ .Values.glpi.phpfpm.image.pullPolicy }}
+              {{- with .Values.glpi.securityContext }}
+              securityContext:
+                {{- toYaml . | nindent 16 }}
+              {{- end }}
+              command: ["/bin/sh", "/scripts/glpi-backup.sh"]
+              env:
+                - name: BACKUP_ARCHIVE_PREFIX
+                  value: {{ .Values.glpi.backup.archivePrefix | quote }}
+              resources:
+                {{- toYaml .Values.glpi.backup.resources | nindent 16 }}
+              volumeMounts:
+                - name: scripts
+                  mountPath: /scripts
+                - name: backup-workdir
+                  mountPath: /backup/out
+                {{- if .Values.glpi.backup.volumes.files }}
+                - name: files
+                  mountPath: /backup/source/files
+                  readOnly: true
+                {{- end }}
+                {{- if .Values.glpi.backup.volumes.marketplace }}
+                - name: marketplace
+                  mountPath: /backup/source/marketplace
+                  readOnly: true
+                {{- end }}
+                {{- if .Values.glpi.backup.volumes.etc }}
+                - name: etc
+                  mountPath: /backup/source/etc
+                  readOnly: true
+                {{- end }}
+          containers:
+            - name: upload
+              image: "{{ .Values.glpi.backup.images.uploader.repository }}:{{ .Values.glpi.backup.images.uploader.tag }}"
+              imagePullPolicy: {{ .Values.glpi.backup.images.uploader.pullPolicy }}
+              command: ["/bin/sh", "/scripts/upload-backup.sh"]
+              env:
+                - name: S3_ENDPOINT
+                  value: {{ .Values.glpi.backup.s3.endpoint | quote }}
+                - name: S3_BUCKET
+                  value: {{ .Values.glpi.backup.s3.bucket | quote }}
+                - name: S3_PREFIX
+                  value: {{ .Values.glpi.backup.s3.prefix | quote }}
+                - name: S3_CREATE_BUCKET_IF_NOT_EXISTS
+                  value: {{ ternary "true" "false" .Values.glpi.backup.s3.createBucketIfNotExists | quote }}
+                - name: S3_ACCESS_KEY
+                  valueFrom:
+                    secretKeyRef:
+                      name: {{ include "glpi.backup.secretName" . }}
+                      key: {{ .Values.glpi.backup.s3.existingSecretAccessKeyKey }}
+                - name: S3_SECRET_KEY
+                  valueFrom:
+                    secretKeyRef:
+                      name: {{ include "glpi.backup.secretName" . }}
+                      key: {{ .Values.glpi.backup.s3.existingSecretSecretKeyKey }}
+              resources:
+                {{- toYaml .Values.glpi.backup.resources | nindent 16 }}
+              volumeMounts:
+                - name: scripts
+                  mountPath: /scripts
+                - name: backup-workdir
+                  mountPath: /backup/out
+          volumes:
+            - name: scripts
+              configMap:
+                name: {{ include "glpi.fullname" . }}-backup-scripts
+                defaultMode: 0755
+            - name: backup-workdir
+              emptyDir: {}
+            {{- if .Values.glpi.backup.volumes.files }}
+            - name: files
+              persistentVolumeClaim:
+                claimName: glpi-files
+            {{- end }}
+            {{- if .Values.glpi.backup.volumes.marketplace }}
+            - name: marketplace
+              persistentVolumeClaim:
+                claimName: glpi-marketplace
+            {{- end }}
+            {{- if .Values.glpi.backup.volumes.etc }}
+            - name: etc
+              persistentVolumeClaim:
+                claimName: glpi-etc
+            {{- end }}
+{{- end }}

--- a/helm/templates/glpi-backup-secret.yaml
+++ b/helm/templates/glpi-backup-secret.yaml
@@ -1,0 +1,13 @@
+{{- if and (include "glpi.backup.enabled" .) (not .Values.glpi.backup.s3.existingSecret) }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "glpi.backup.secretName" . }}
+  namespace: {{ include "glpi.namespace" . }}
+  labels:
+    {{- include "glpi.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  {{ .Values.glpi.backup.s3.existingSecretAccessKeyKey }}: {{ .Values.glpi.backup.s3.accessKey | quote }}
+  {{ .Values.glpi.backup.s3.existingSecretSecretKeyKey }}: {{ .Values.glpi.backup.s3.secretKey | quote }}
+{{- end }}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -255,6 +255,67 @@ glpi:
     # Schedule in cron format (default: every 2 minutes)
     schedule: "*/2 * * * *"
 
+  # -- Files Backup Configuration
+  # Periodically archives the files/marketplace/etc PVCs (uploads, documents, sessions,
+  # marketplace plugins, GLPI config) to S3-compatible storage. Mirrors the naming and
+  # implementation pattern of the helmforge/mariadb subchart's own backup.* (same uploader
+  # image, same existingSecret convention) - use that subchart's backup.enabled for database
+  # backups; this is the files-only counterpart, since GLPI's actual data lives on PVCs the
+  # mariadb subchart has no knowledge of.
+  backup:
+    # -- Enable the files backup CronJob. Requires s3.endpoint and s3.bucket to be set.
+    enabled: false
+    # -- Backup schedule in Cron format
+    schedule: "0 3 * * *"
+    # -- Suspend backup execution
+    suspend: false
+    # -- CronJob concurrency policy
+    concurrencyPolicy: Forbid
+    # -- Successful job history retained by the CronJob
+    successfulJobsHistoryLimit: 3
+    # -- Failed job history retained by the CronJob
+    failedJobsHistoryLimit: 3
+    # -- Job backoff limit
+    backoffLimit: 1
+    # -- Prefix used in generated backup archive names
+    archivePrefix: glpi
+    # -- Resources applied to the backup (tar) and upload containers
+    resources: {}
+    images:
+      # -- MinIO client image used to upload the archive to S3. Same image as the
+      # helmforge/mariadb subchart's backup.images.uploader, for consistency.
+      uploader:
+        repository: docker.io/helmforge/mc
+        tag: "1.0.0"
+        pullPolicy: IfNotPresent
+    # -- Which persistent volumes to include in the backup archive. Disable individually to
+    # reduce archive size/backup time - e.g. skip `files` (usually the largest, holding
+    # uploads/documents) if it is already covered by a separate volume-level snapshot policy
+    # (CSI VolumeSnapshot, cloud disk snapshots, etc).
+    volumes:
+      files: true
+      marketplace: true
+      etc: true
+    s3:
+      # -- S3-compatible endpoint URL, for example: https://s3.amazonaws.com or https://minio.example.com
+      endpoint: ""
+      # -- Target bucket name
+      bucket: ""
+      # -- Optional key prefix inside the bucket
+      prefix: glpi
+      # -- Create the bucket automatically when it does not exist yet
+      createBucketIfNotExists: true
+      # -- Existing secret containing access-key and secret-key
+      existingSecret: ""
+      # -- Secret key name for the access key inside s3.existingSecret
+      existingSecretAccessKeyKey: access-key
+      # -- Secret key name for the secret key inside s3.existingSecret
+      existingSecretSecretKeyKey: secret-key
+      # -- Inline access key used when s3.existingSecret is not set
+      accessKey: ""
+      # -- Inline secret key used when s3.existingSecret is not set
+      secretKey: ""
+
   # -- GLPI Pod Security Context
   # Security settings applied at the pod level
   podSecurityContext:


### PR DESCRIPTION
Closes half of #1 ("Add cronjob to backup: Database, Files"). The
database half is already covered by the helmforge/mariadb subchart's
own native backup.enabled (S3-backed CronJob) - this is the files-only
counterpart, since GLPI's actual data (uploads, documents, sessions,
marketplace plugins, config) lives on this chart's own PVCs, which the
mariadb subchart has no knowledge of.

## Design

Deliberately mirrors the helmforge/mariadb subchart's own backup.*
implementation as closely as possible - same naming convention
(schedule/suspend/concurrencyPolicy/archivePrefix/s3.*), same uploader
image (docker.io/helmforge/mc), same existingSecret-or-generated-Secret
pattern, same initContainer(dump)+container(upload) split - so an
operator already familiar with the DB backup config finds this one
predictable, and both can share a single S3 bucket/mental model.

- `glpi.backup.enabled` (default false) gates a new CronJob
  ({release}-backup) with an initContainer that tars whichever of
  files/marketplace/etc are enabled via `glpi.backup.volumes.*` (all
  three by default; individually toggleable, e.g. to skip `files` - the
  usual largest volume - if it's already covered by CSI VolumeSnapshots)
  and a container that uploads the resulting archive to S3 via `mc`.
- Added glpi.backup.enabled / glpi.backup.secretName helpers with the
  same fail-fast validation as the mariadb subchart's own
  mariadb.backupEnabled (missing s3.endpoint/bucket, or all three
  volumes disabled, fails at template-render time with a clear message
  instead of the CronJob silently failing every run).
- New templates: glpi-backup-cronjob.yaml, glpi-backup-configmap.yaml
  (the two scripts, adapted from the mariadb subchart's own
  mariadb-backup.sh/upload-backup.sh), glpi-backup-secret.yaml (S3
  credentials, skipped entirely when s3.existingSecret is set).

## Testing

- helm lint --strict: 0 failures
- helm template (default): nothing rendered
- helm template --set glpi.backup.enabled=true (no endpoint/bucket):
  fails fast with "glpi.backup.s3.endpoint is required..."
- helm template with full backup config: CronJob/ConfigMap/Secret all
  render correctly with the right env/secretKeyRef wiring
- Full live kind cluster test with a real MinIO instance as the S3
  backend:
  - helm install with glpi.backup.enabled=true pointed at MinIO:
    STATUS deployed
  - Manually triggered a Job from the CronJob AND let the schedule fire
    on its own - both produced archives, confirmed present in MinIO via
    `mc ls` (glpi-files-<timestamp>.tar.gz, ~265-285KiB each)
  - Downloaded one archive back out and inspected it with `tar -tzf`:
    602 real entries confirmed, including files/_cache/**,
    files/_sessions/sess_*, files/_log/cron.log,
    files/_log/php-errors.log, and marketplace/ - genuine GLPI runtime
    data, not an empty/corrupted archive

