### PR TITLE
feat(chart): support existingSecret for externalDatabase, fail fast on misconfiguration

### DIFF
--- a/helm/templates/_helpers.tpl
+++ b/helm/templates/_helpers.tpl
@@ -165,4 +165,73 @@ existingSecret with a non-default key name is respected.
 {{- .Values.mariadb.auth.existingSecretUserPasswordKey | default "mariadb-user-password" -}}
 {{- end }}
 
+{{/*
+Return the name of the Secret holding the external database password: either the user-supplied
+externalDatabase.existingSecret, or this chart's own generated Secret ({fullname}-externaldb).
+Mirrors the same existingSecret-or-generated pattern used by mainstream charts for this exact
+scenario (e.g. bitnami/moodle's externalDatabase.existingSecret + moodle.databaseSecretName) -
+a fixed, documented key name (see glpi.database.secretPasswordKey) rather than a second
+customizable "which key" field, since this is chart-owned/generated in the common case. Only
+meaningful when mariadb.enabled is false.
+*/}}
+{{- define "glpi.externalDatabase.secretName" -}}
+{{- if .Values.externalDatabase.existingSecret -}}
+{{- .Values.externalDatabase.existingSecret -}}
+{{- else -}}
+{{- printf "%s-externaldb" (include "glpi.fullname" .) -}}
+{{- end -}}
+{{- end }}
+
+{{/*
+Return the name of the Secret holding the database password GLPI should connect with, whether
+that's the internal helmforge/mariadb subchart (mariadb.enabled: true) or an external database
+(mariadb.enabled: false). Lets every consumer (php-fpm, jobs, cronjob) use a single, unconditional
+secretKeyRef instead of duplicating the mariadb.enabled branch in each template.
+*/}}
+{{- define "glpi.database.secretName" -}}
+{{- if .Values.mariadb.enabled -}}
+{{- include "glpi.mariadb.secretName" . -}}
+{{- else -}}
+{{- include "glpi.externalDatabase.secretName" . -}}
+{{- end -}}
+{{- end }}
+
+{{/*
+Return the key within glpi.database.secretName that holds the database password. See
+glpi.mariadb.secretPasswordKey for the mariadb.enabled case; externalDatabase always uses a
+fixed "password" key (whether in a user-supplied existingSecret or this chart's own generated
+one), documented in values.yaml.
+*/}}
+{{- define "glpi.database.secretPasswordKey" -}}
+{{- if .Values.mariadb.enabled -}}
+{{- include "glpi.mariadb.secretPasswordKey" . -}}
+{{- else -}}
+password
+{{- end -}}
+{{- end }}
+
+{{/*
+Fail fast with a clear error when mariadb.enabled is false but externalDatabase is missing
+required fields, instead of silently rendering an empty MARIADB_HOST that leaves the
+wait-for-mariadb initContainers (`nc -z "" 3306`) hanging indefinitely on every install/upgrade.
+Call from a template that always renders (glpi-configmap.yaml) so this runs regardless of which
+specific resource Helm happens to template/install first.
+*/}}
+{{- define "glpi.externalDatabase.validate" -}}
+{{- if not .Values.mariadb.enabled -}}
+  {{- if not .Values.externalDatabase.host -}}
+    {{- fail "externalDatabase.host is required when mariadb.enabled is false" -}}
+  {{- end -}}
+  {{- if not .Values.externalDatabase.database -}}
+    {{- fail "externalDatabase.database is required when mariadb.enabled is false" -}}
+  {{- end -}}
+  {{- if not .Values.externalDatabase.username -}}
+    {{- fail "externalDatabase.username is required when mariadb.enabled is false" -}}
+  {{- end -}}
+  {{- if not (or .Values.externalDatabase.existingSecret .Values.externalDatabase.password) -}}
+    {{- fail "either externalDatabase.existingSecret or externalDatabase.password is required when mariadb.enabled is false" -}}
+  {{- end -}}
+{{- end -}}
+{{- end }}
+
 

--- a/helm/templates/glpi-configmap.yaml
+++ b/helm/templates/glpi-configmap.yaml
@@ -1,3 +1,4 @@
+{{- include "glpi.externalDatabase.validate" . }}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/helm/templates/glpi-cronjob.yaml
+++ b/helm/templates/glpi-cronjob.yaml
@@ -51,14 +51,12 @@ spec:
                     name: glpi-config
                 - secretRef: 
                     name: glpi-secret
-              {{- if .Values.mariadb.enabled }}
               env:
                 - name: MARIADB_PASSWORD
                   valueFrom:
                     secretKeyRef:
-                      name: {{ include "glpi.mariadb.secretName" . }}
-                      key: {{ include "glpi.mariadb.secretPasswordKey" . }}
-              {{- end }}
+                      name: {{ include "glpi.database.secretName" . }}
+                      key: {{ include "glpi.database.secretPasswordKey" . }}
               command: 
                 - php
                 - front/cron.php

--- a/helm/templates/glpi-deployment.yaml
+++ b/helm/templates/glpi-deployment.yaml
@@ -65,14 +65,12 @@ spec:
                 name: glpi-config
             - secretRef:
                 name: glpi-secret
-          {{- if .Values.mariadb.enabled }}
           env:
             - name: MARIADB_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: {{ include "glpi.mariadb.secretName" . }}
-                  key: {{ include "glpi.mariadb.secretPasswordKey" . }}
-          {{- end }}
+                  name: {{ include "glpi.database.secretName" . }}
+                  key: {{ include "glpi.database.secretPasswordKey" . }}
           ports:
             - containerPort: 9000
               name: fpm

--- a/helm/templates/glpi-externaldb-secret.yaml
+++ b/helm/templates/glpi-externaldb-secret.yaml
@@ -1,0 +1,12 @@
+{{- if and (not .Values.mariadb.enabled) (not .Values.externalDatabase.existingSecret) }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "glpi.externalDatabase.secretName" . }}
+  namespace: {{ include "glpi.namespace" . }}
+  labels:
+    {{- include "glpi.labels" . | nindent 4 }}
+type: Opaque
+data:
+  password: {{ .Values.externalDatabase.password | b64enc | quote }}
+{{- end }}

--- a/helm/templates/glpi-job.yaml
+++ b/helm/templates/glpi-job.yaml
@@ -40,14 +40,12 @@ spec:
                 name: glpi-config
             - secretRef:
                 name: glpi-secret
-          {{- if .Values.mariadb.enabled }}
           env:
             - name: MARIADB_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: {{ include "glpi.mariadb.secretName" . }}
-                  key: {{ include "glpi.mariadb.secretPasswordKey" . }}
-          {{- end }}
+                  name: {{ include "glpi.database.secretName" . }}
+                  key: {{ include "glpi.database.secretPasswordKey" . }}
           command:
             - sh
             - -c
@@ -152,14 +150,12 @@ spec:
                 name: glpi-config
             - secretRef:
                 name: glpi-secret
-          {{- if .Values.mariadb.enabled }}
           env:
             - name: MARIADB_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: {{ include "glpi.mariadb.secretName" . }}
-                  key: {{ include "glpi.mariadb.secretPasswordKey" . }}
-          {{- end }}
+                  name: {{ include "glpi.database.secretName" . }}
+                  key: {{ include "glpi.database.secretPasswordKey" . }}
           volumeMounts:
             - name: files
               mountPath: /var/lib/glpi
@@ -260,14 +256,12 @@ spec:
                 name: glpi-config
             - secretRef:
                 name: glpi-secret
-          {{- if .Values.mariadb.enabled }}
           env:
             - name: MARIADB_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: {{ include "glpi.mariadb.secretName" . }}
-                  key: {{ include "glpi.mariadb.secretPasswordKey" . }}
-          {{- end }}
+                  name: {{ include "glpi.database.secretName" . }}
+                  key: {{ include "glpi.database.secretPasswordKey" . }}
           volumeMounts:
             - name: files
               mountPath: /var/lib/glpi
@@ -368,14 +362,12 @@ spec:
                 name: glpi-config
             - secretRef:
                 name: glpi-secret
-          {{- if .Values.mariadb.enabled }}
           env:
             - name: MARIADB_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: {{ include "glpi.mariadb.secretName" . }}
-                  key: {{ include "glpi.mariadb.secretPasswordKey" . }}
-          {{- end }}
+                  name: {{ include "glpi.database.secretName" . }}
+                  key: {{ include "glpi.database.secretPasswordKey" . }}
           volumeMounts:
             - name: etc
               mountPath: /etc/glpi

--- a/helm/templates/glpi-secret.yaml
+++ b/helm/templates/glpi-secret.yaml
@@ -20,10 +20,15 @@ data:
   glpi.mariadb.secretName in _helpers.tpl and its usage in glpi-deployment.yaml/glpi-job.yaml/
   glpi-cronjob.yaml.
   */}}
-  {{- else if .Values.externalDatabase }}
+  {{- else }}
   MARIADB_DATABASE: {{ .Values.externalDatabase.database | b64enc | quote }}
   MARIADB_USER: {{ .Values.externalDatabase.username | b64enc | quote }}
-  MARIADB_PASSWORD: {{ .Values.externalDatabase.password | b64enc | quote }}
+  {{- /*
+  MARIADB_PASSWORD is intentionally NOT set here, same reasoning as the mariadb.enabled case
+  above: consumers read it via secretKeyRef from glpi.database.secretName instead, so that
+  externalDatabase.existingSecret (Doppler / External Secrets / Vault / sealed-secrets, etc)
+  is actually respected instead of silently rendering an empty password.
+  */}}
   {{- end }}
   {{- if and (not .Values.valkey.enabled) .Values.externalCache.host .Values.externalCache.password }}
   {{- $scheme := "redis" }}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -523,7 +523,9 @@ tolerations: []
 affinity: {}
 
 # -- External Database Configuration
-# Used when mariadb.enabled is false
+# Used when mariadb.enabled is false. host/database/username are required in that case (the
+# chart fails fast at template-render time otherwise, rather than leaving the wait-for-mariadb
+# initContainers hanging against an empty host).
 externalDatabase:
   # External database hostname or IP
   host: ""
@@ -533,8 +535,13 @@ externalDatabase:
   database: ""
   # External database username
   username: ""
-  # External database password
+  # External database password. Ignored when existingSecret is set.
   password: ""
+  # -- Name of a pre-existing Secret (Doppler / External Secrets / Vault / sealed-secrets, etc)
+  # containing the external database password, instead of the plaintext value above. Must
+  # contain a key named "password". When left empty, the chart generates its own Secret from
+  # the plaintext password above (unchanged default behavior).
+  existingSecret: ""
 
 # -- External Cache Configuration
 # Used when valkey.enabled is false


### PR DESCRIPTION
## Problem

externalDatabase.password (used when mariadb.enabled: false, e.g. RDS /
Cloud SQL / Azure Database) could only be set as a plaintext value in
values.yaml - no existingSecret alternative, unlike the internal
mariadb.auth.existingSecret the helmforge/mariadb subchart already
supports. This is exactly the audience (managed external databases)
most likely to run GitOps/Vault/Doppler/External Secrets workflows and
want to avoid plaintext passwords in values.yaml/release history.

Separately, if mariadb.enabled is set to false without configuring
externalDatabase.host, the chart silently rendered MARIADB_HOST: "" -
the wait-for-mariadb initContainers (`nc -z "" 3306`) then hang
indefinitely on every install/upgrade instead of failing with a clear
error.

## Design

Mirrors the pattern used by mainstream charts for this exact scenario
(verified against bitnami/moodle, which has the same
mariadb.enabled-or-externalDatabase shape): externalDatabase.existingSecret,
falling back to a chart-generated Secret from the plaintext password
when unset, both read via a fixed, documented key ("password") rather
than a second customizable "which key" field.

- Added externalDatabase.existingSecret to values.yaml.
- Added glpi.externalDatabase.secretName helper (existingSecret, or
  this chart's own generated {fullname}-externaldb Secret).
- Added glpi.database.secretName / glpi.database.secretPasswordKey
  helpers that resolve to either the internal mariadb subchart's secret
  or the external database's secret depending on mariadb.enabled - lets
  every consumer (php-fpm, the 4 DB-touching init Jobs, cronjob) use a
  single unconditional secretKeyRef instead of duplicating the
  mariadb.enabled branch in each template.
- Added glpi.externalDatabase.validate: fails fast with a clear message
  if mariadb.enabled is false and host/database/username are missing,
  or neither existingSecret nor password is set. Invoked from
  glpi-configmap.yaml since that template always renders regardless of
  which specific resource Helm processes first.
- New glpi-externaldb-secret.yaml: generates the chart-owned Secret,
  skipped entirely when existingSecret is set.
- glpi-secret.yaml no longer inlines MARIADB_PASSWORD for the
  externalDatabase case (same reasoning as the mariadb.enabled fix in
  #191: doing so would silently render an empty password whenever
  existingSecret is used).

## Testing

- helm lint --strict: 0 failures
- helm template (default, mariadb.enabled=true): unchanged, still reads
  MARIADB_PASSWORD from the mariadb subchart's own secret
- helm template with externalDatabase + plaintext password: chart
  generates its own Secret correctly (verified the base64 value decodes
  back to the plaintext password)
- helm template with externalDatabase.existingSecret set: secretKeyRef
  points directly at it, no chart-generated Secret rendered at all
- helm template with mariadb.enabled=false and progressively missing
  fields: 3 separate fail-fast errors, one per missing
  host/database/(password-or-existingSecret)
- Full live kind cluster test: deployed a standalone MariaDB Deployment
  simulating an external/managed database, plus a manually-created
  Secret simulating a Vault/Doppler-injected one
  - With externalDatabase.existingSecret pointing to it: `helm install`
    completed (STATUS: deployed, meaning the dbInstall/dbConfigure hooks
    genuinely connected and configured the external DB), confirmed no
    internal mariadb subchart pod was created, php-fpm's MARIADB_PASSWORD
    env var matches the external secret exactly, no chart-generated
    Secret exists, and GLPI served its real login page (HTTP 200,
    "Authentication - GLPI")
  - Re-ran with externalDatabase.password (plaintext) instead: confirmed
    the chart-generated Secret exists this time, HTTP 200 again

